### PR TITLE
Include all routehints when creating an invoice

### DIFF
--- a/libs/gl-plugin/src/requests.rs
+++ b/libs/gl-plugin/src/requests.rs
@@ -193,3 +193,13 @@ pub struct Keysend {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ListIncoming {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ListChannels {
+     #[serde(skip_serializing_if = "Option::is_none")]
+    pub short_channel_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
+}

--- a/libs/gl-plugin/src/responses.rs
+++ b/libs/gl-plugin/src/responses.rs
@@ -1,8 +1,8 @@
-/// Various structs representing JSON-RPC responses
-use serde::Deserialize;
+//! Various structs representing JSON-RPC responses
+
 use clightningrpc::common::MSat;
 pub use clightningrpc::responses::*;
-
+use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Withdraw {
@@ -235,4 +235,22 @@ pub struct Peer {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ListPeers {
     pub peers: Vec<Peer>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListChannelsChannel {
+    pub source: String,
+    pub destination: String,
+    pub short_channel_id: String,
+    pub public: bool,
+    pub satoshis: u64,
+    pub active: bool,
+    pub base_fee_millisatoshi: u64,
+    pub fee_per_millionth: u32,
+    pub delay: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListChannels {
+    pub channels: Vec<ListChannelsChannel>,
 }

--- a/libs/gl-plugin/src/rpc.rs
+++ b/libs/gl-plugin/src/rpc.rs
@@ -1,13 +1,13 @@
 use crate::{requests, responses};
 use clightningrpc::{error::Error, Response};
+use cln_rpc::codec::JsonCodec;
+use futures::{SinkExt, StreamExt};
 use log::{debug, error, trace, warn};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Deserializer, Value};
 use std::path::{Path, PathBuf};
 use tokio::net::UnixStream;
 use tokio_util::codec::Framed;
-use cln_rpc::codec::JsonCodec;
-use futures::{SinkExt, StreamExt};
 
 #[derive(Clone, Debug)]
 pub struct LightningClient {
@@ -158,5 +158,22 @@ impl LightningClient {
     pub async fn listincoming(&self) -> Result<crate::responses::ListIncoming, Error> {
         self.call("listincoming", crate::requests::ListIncoming {})
             .await
+    }
+
+    pub async fn listchannels(
+        &self,
+        short_channel_id: Option<String>,
+        source: Option<String>,
+        destination: Option<String>,
+    ) -> Result<crate::responses::ListChannels, Error> {
+        self.call(
+            "listchannels",
+            crate::requests::ListChannels {
+                short_channel_id,
+                source,
+                destination,
+            },
+        )
+        .await
     }
 }

--- a/libs/gl-testing/tests/test_node.py
+++ b/libs/gl-testing/tests/test_node.py
@@ -66,9 +66,6 @@ def test_node_network(node_factory, clients, bitcoind):
 
     # Now wait for the channel to confirm
     wait_for(lambda: gl1.list_peers().peers[0].channels[0].state == 'CHANNELD_NORMAL')
-    import time
-    time.sleep(5)
-
     inv = gl1.create_invoice('test', nodepb.Amount(millisatoshi=10000)).bolt11
     decoded = l1.rpc.decodepay(inv)
     pprint(decoded)


### PR DESCRIPTION
When creating an invoice we should do our best to include as many
routehints as possible since this maximizes our chances of a
successful incoming payment.

Before this patch we'd actually select active, i.e., connected,
channels only, which causes a race in Greenlight where we might end up
creating an invoice before the channel has become active again. Now we
consider all channels that are in an updateable state as potential
routehints.

A further complication comes for newly funded channels, where we need
to join information from `listpeers` (local channel status) as well as
`listchannels` (routing information). Since `gossipd` may be slightly
delayed we need to introduce a slight delay as well, but it's worth it
since it massively increases the chances of a successful incoming
payment.

The delay is capped at 5 seconds at the moment.

Fixes #25
