### PR TITLE
test: new test funding channel from greenlight

### DIFF
--- a/libs/gl-testing/tests/test_gl_node.py
+++ b/libs/gl-testing/tests/test_gl_node.py
@@ -1,0 +1,35 @@
+from gltesting.identity import Identity
+from gltesting.fixtures import *
+from pyln.testing.utils import wait_for
+from rich.pretty import pprint
+from glclient import nodepb
+import time
+
+def test_node_network_gl_fund(node_factory, clients, bitcoind):
+    """Setup a small network and check that we can send/receive payments.
+
+    ```dot
+    l1 -> l2 -> gl1
+    ```
+    """
+    l1, l2 = node_factory.line_graph(2)
+    c = clients.new()
+    c.register(configure=True)
+    gl1 = c.node()
+
+    # Handshake needs signer for ECDH of Noise_XK exchange
+    s = c.signer().run_in_thread()
+    gl1.connect_peer(l2.info['id'], f'127.0.0.1:{l2.daemon.port}')
+    gl1.connect_peer(l1.info['id'], f'127.0.0.1:{l1.daemon.port}')
+
+    # Fund gl1
+    gl1_address = gl1.new_address().address
+    bitcoind.rpc.sendtoaddress(gl1_address, 1)
+    bitcoind.generate_block(1, wait_for_mempool=1)
+    wait_for(lambda: len(gl1.list_funds().outputs) > 0 )
+
+    # Now open a channel from gl1 -> l2
+    l1_node_id = l1.rpc.getinfo()['id']
+    channel_result = gl1.fund_channel(l1_node_id, nodepb.Amount(millisatoshi=50000000))
+    bitcoind.generate_block(1, wait_for_mempool=1)
+


### PR DESCRIPTION
This added test fail with:

```
ValueError: error calling remote method: status: Internal, message: "RPC error response: RpcError { code: -1, message: \"They sent error channel 82cc0de4d6eaa24dd85e82315d05bde02e1510601a7eda8afbabacbe87e175f5: You gave bad parameters: feerate_per_kw 253 below minimum 1875\", data: Some(Object {\"id\": String(\"0266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518\"), \"method\": String(\"fundchannel_start\")}) }", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Tue, 06 Sep 2022 14:04:58 GMT"} }

/tmp/venv/lib/python3.8/site-packages/glclient/__init__.py
```

However, `fund_channel` doesn't allow setting the fees at the moment.

I also tried `dev-feerate` but I've got "bad connected peer"