### PR TITLE
plugin: Make warning about duplicate results less noisy

### DIFF
--- a/libs/gl-plugin/src/stager.rs
+++ b/libs/gl-plugin/src/stager.rs
@@ -81,10 +81,13 @@ impl Stage {
                     Ok(())
                 }
             }
-            None => Err(anyhow!(
-                "Request {} not found, is this a duplicate result?",
-                response.request_id
-            )),
+            None => {
+                trace!(
+                    "Request {} not found, is this a duplicate result?",
+                    response.request_id
+                );
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
Duplicate results, while interesting for debugging, are likely too alarming for users if we print them in the logs, so reduce their verbosity.