### PR TITLE
testing: We should not be able to register twice

### DIFF
--- a/libs/gl-testing/gltesting/scheduler.py
+++ b/libs/gl-testing/gltesting/scheduler.py
@@ -119,6 +119,12 @@ class Scheduler(object):
         assert challenge.scope == schedpb.ChallengeScope.REGISTER
         # TODO Verify that the response matches the challenge.
 
+        # Check that we don't already have this node registered:
+        if len([n for n in self.nodes if n.node_id == req.node_id]) > 0:
+            raise ValueError(
+                "could not register the node with the DB, does the node already exist?"
+            )
+
         num = len(self.nodes)
         hex_node_id = challenge.node_id.hex()
         certs.genca(f"/users/{hex_node_id}")

--- a/libs/gl-testing/tests/test_scheduler.py
+++ b/libs/gl-testing/tests/test_scheduler.py
@@ -22,3 +22,12 @@ def test_scheduler_recover(scheduler, clients):
 
     assert((c.directory / "device.crt").exists())
     assert((c.directory / "device-key.pem").exists())
+
+
+def test_scheduler_duplicate_node(scheduler, clients):
+    """The scheduler must fail duplicate register calls
+    """
+    c = clients.new()
+    r = c.register(configure=False)
+    with pytest.raises(Exception):
+        r = c.register(configure=False)


### PR DESCRIPTION
We didn't check if a node was already registered, unlike the actual scheduler which does this via a SQL constraint. Now we do :-)

Reported-by: Riccardo Casatta <@rcasatta>
Signed-off-by: Christian Decker <@cdecker>