### PR TITLE
Add sign_invoice method to signer

### DIFF
--- a/libs/gl-client/src/signer.rs
+++ b/libs/gl-client/src/signer.rs
@@ -352,7 +352,7 @@ impl Signer {
             .handler()
             .handle(vls_protocol::msgs::from_vec(msg.clone())?)
             .map_err(|_| anyhow!("Sign invoice failed"))?;
-        Ok(sig.0.as_vec())
+        Ok(sig.0.as_vec()[2..67].to_vec())
     }
 
     /// Create a Node stub from this instance of the signer, configured to


### PR DESCRIPTION
This PR is for adding ability to sign an invoice using greenlight signer.
The input format is according to: https://github.com/ElementsProject/lightning/blob/master/hsmd/hsmd_wire.csv#L107
The output represents a `RecoverableSignature` and the caller is able to construct such instance via this code:

```
let rid = RecoveryId::from_i32(raw_result[64] as i32).expect("recovery ID");
let sig = &raw_result[0..64];
let recoverable_sig = RecoverableSignature::from_compact(sig, rid).unwrap();

```