### PR TITLE
testing: Add missing `coverage` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ build-self: ensure-docker
 	(cd libs/gl-client-py && \
 	maturin build --strip && \
 	pip install --force-reinstall /tmp/target/wheels/gl_client_py*.whl)
+	pip install coverage
 
 check-self: ensure-docker
 	PYTHONPATH=/repo/libs/gl-testing pytest -vvv /repo/libs/gl-testing -n=$(shell nproc) --cov=glclient --cov-report=html


### PR DESCRIPTION
We added it to the pytest run, but didn't add it to the list of dependencies