### PR TITLE
plugin: Fix `pay` for without amounts

### DIFF
--- a/libs/gl-plugin/src/pb.rs
+++ b/libs/gl-plugin/src/pb.rs
@@ -388,7 +388,7 @@ impl From<PayRequest> for requests::Pay {
     fn from(p: PayRequest) -> Self {
         requests::Pay {
             bolt11: p.bolt11,
-            amount: None,
+            amount: p.amount.map(|a| a.try_into().unwrap()),
             retry_for: match p.timeout {
                 0 => None,
                 v => Some(v),

--- a/libs/gl-testing/tests/test_node.py
+++ b/libs/gl-testing/tests/test_node.py
@@ -128,7 +128,6 @@ def test_cln_grpc_interface(clients):
     print(info)
 
 
-@unittest.skip("Demonstrating issue paying amountless invoices")
 def test_node_invoice_amountless(bitcoind, node_factory, clients):
     """Test that the request is being mapped correctly.
     ```dot


### PR DESCRIPTION
@erdemyerebasmaz reported that we somehow lose the `amount_msat` field to `pay` calls over the grpc interface. This PR tests that and then fixes it.