### PR TITLE
gltesting: Add bitcoind proxy to mock feerates

### DIFF
--- a/libs/gl-testing/tests/test_node.py
+++ b/libs/gl-testing/tests/test_node.py
@@ -134,9 +134,7 @@ def test_node_invoice_amountless(bitcoind, node_factory, clients):
     l1 -> gl1
     ```
     """
-    l1 = node_factory.get_node(may_restart=True)
-    l1.set_feerates([1] * 4, wait_for_effect=True)
-    l1.restart()
+    l1 = node_factory.get_node()
     c = clients.new()
     c.register(configure=True)
     gl1 = c.node()


### PR DESCRIPTION
We were mocking the feerates on the non-GL side, but not on the GL side. This mismatch meant that we could not open an outgoing channel from GL to non-GL. Now that works.

This should make #34 work as well.