### PR TITLE
rs: Rewire the way we use custom keys and certificates for apps

### DIFF
--- a/libs/gl-client/build.rs
+++ b/libs/gl-client/build.rs
@@ -1,44 +1,33 @@
-use std::process::Command;
-
 const NOBODY_CRT: &'static str = "../../tls/users-nobody.pem";
 const NOBODY_KEY: &'static str = "../../tls/users-nobody-key.pem";
 
-const DEFAULT_NOBODY_CERT: &'static str = "../../tls/default/users-nobody.pem";
-const DEFAULT_NOBODY_KEY: &'static str = "../../tls/default/users-nobody-key.pem";
+use std::env::var;
 
 fn main() {
-    // Do we have a custom `NOBODY` user?
-    let nobody_cert = match option_env!("GL_CUSTOM_NOBODY_CERT") {
-        Some(s) => s,
-        None => {
-            println!("cargo:warning=Using default NOBODY cert. Set \"GL_CUSTOM_NOBODY_CERT\" to use a custom cert.");
-            DEFAULT_NOBODY_CERT
+    // Either both are set or none is :-) We set an env-var for
+    // `rustc` to pick up and include using `env!`.
+    let vars = match (var("GL_CUSTOM_NOBODY_KEY"), var("GL_CUSTOM_NOBODY_CERT")) {
+        (Ok(a), Ok(b)) => (a, b),
+        (Err(_), Err(_)) => {
+            println!("cargo:warning=Using default NOBODY cert.");
+            println!("cargo:warning=Set \"GL_CUSTOM_NOBODY_KEY\" and \"GL_CUSTOM_NOBODY_CERT\" to use a custom cert.");
+            (NOBODY_KEY.to_owned(), NOBODY_CRT.to_owned())
+        }
+        (Ok(_), Err(_)) => {
+            println!("Missing GL_CUSTOM_NOBODY_CERT, since you are using GL_CUSTOM_NOBODY_KEY");
+            std::process::exit(1);
+        }
+        (Err(_), Ok(_)) => {
+            println!("Missing GL_CUSTOM_NOBODY_KEY, since you are using GL_CUSTOM_NOBODY_CERT");
+            std::process::exit(1);
         }
     };
-    let nobody_key = match option_env!("GL_CUSTOM_NOBODY_KEY") {
-        Some(s) => s,
-        None => {
-            println!("cargo:warning=Using default NOBODY key. Set \"GL_CUSTOM_NOBODY_KEY\" to use a custom key.");
-            DEFAULT_NOBODY_KEY
-        }
-    };
+    println!("cargo:rustc-env=GL_NOBODY_KEY={}", vars.0);
+    println!("cargo:rustc-env=GL_NOBODY_CRT={}", vars.1);
 
-    // Only one of the custom `NOBODY` env vars is set. This can not be intended.
-    // Better panic and throw an error!
-    if !(nobody_cert.is_empty() && nobody_key.is_empty())
-        && (nobody_cert.is_empty() || nobody_key.is_empty())
-    {
-        panic!("Only one of GL_CUSTOM_NOBODY_CERT and GL_CUSTOM_NOBODY_KEY is set. Set both or none.")
-    }
-
-    // Write the `NOBODY` user cert and key
-    let mut cp = Command::new("cp");
-    cp.args([nobody_cert, NOBODY_CRT]);
-    cp.output().unwrap();
-
-    let mut cp = Command::new("cp");
-    cp.args([nobody_key, NOBODY_KEY]);
-    cp.output().unwrap();
+    // Setting a custom certificate causes rebuilds of this crate
+    println!("cargo:rerun-if-env-changed=GL_CUSTOM_NOBODY_CERT");
+    println!("cargo:rerun-if-env-changed=GL_CUSTOM_NOBODY_KEY");
 
     let builder = tonic_build::configure();
 

--- a/libs/gl-client/src/tls.rs
+++ b/libs/gl-client/src/tls.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use tonic::transport::{Certificate, ClientTlsConfig, Identity};
 
 const CA_RAW: &[u8] = include_str!("../../tls/ca.pem").as_bytes();
-const NOBODY_CRT: &[u8] = include_str!("../../tls/users-nobody.pem").as_bytes();
-const NOBODY_KEY: &[u8] = include_str!("../../tls/users-nobody-key.pem").as_bytes();
+const NOBODY_CRT: &[u8] = include_str!(env!("GL_NOBODY_CRT")).as_bytes();
+const NOBODY_KEY: &[u8] = include_str!(env!("GL_NOBODY_KEY")).as_bytes();
 
 /// In order to allow the clients to talk to the
 /// [`crate::scheduler::Scheduler`] a default certificate and private


### PR DESCRIPTION
The custom certificate and key system allows us to bypass the invite system. We used to have a copy-based mechanism for swapping out the certificate and key files, however an envvar-based on is friendlier to the source tree and we can trigger rebuilds based on them too.