### PR TITLE
vls: Pull in the ChainTracker loading fix

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -35,9 +35,9 @@ checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -268,8 +268,7 @@ checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
  "bitcoin_hashes 0.11.0",
- "core2",
- "hashbrown 0.8.2",
+ "bitcoinconsensus",
  "secp256k1 0.24.3",
  "serde",
 ]
@@ -299,7 +298,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
- "core2",
  "serde",
 ]
 
@@ -310,6 +308,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoinconsensus"
+version = "0.20.2-0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54505558b77e0aa21b2491a7b39cbae9db22ac8b1bc543ef4600edb762306f9c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -330,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bolt-derive"
 version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -405,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "num-traits",
@@ -478,12 +486,11 @@ dependencies = [
 [[package]]
 name = "cln-grpc"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6dfb1141b61c16e04c39a05de429f7cc825fd5d2c9e374b59a8db0703a69cd1"
+source = "git+https://github.com/cdecker/lightning.git?branch=20230530-fix-getinfo-address-opt#838bbb21639703fd611019789b8c0287ea992860"
 dependencies = [
  "anyhow",
  "bitcoin 0.29.2",
- "cln-rpc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cln-rpc",
  "hex",
  "log",
  "prost 0.11.9",
@@ -494,11 +501,10 @@ dependencies = [
 [[package]]
 name = "cln-grpc"
 version = "0.1.3"
-source = "git+https://github.com/cdecker/lightning.git?branch=20230530-fix-getinfo-address-opt#838bbb21639703fd611019789b8c0287ea992860"
+source = "git+https://github.com/ElementsProject/lightning.git?branch=master#50a7681171a8a36e6b5b118268bf9f6d1fb11eec"
 dependencies = [
  "anyhow",
  "bitcoin 0.29.2",
- "cln-rpc 0.1.3 (git+https://github.com/cdecker/lightning.git?branch=20230530-fix-getinfo-address-opt)",
  "hex",
  "log",
  "prost 0.11.9",
@@ -521,24 +527,6 @@ dependencies = [
  "serde_json",
  "tokio 1.28.2",
  "tokio-stream",
- "tokio-util 0.7.8",
-]
-
-[[package]]
-name = "cln-rpc"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3b630e345cdfc6f64315414b50815a9eeabbf12438413798bf09e9e79be8b8"
-dependencies = [
- "anyhow",
- "bitcoin 0.29.2",
- "bytes 1.4.0",
- "futures-util",
- "hex",
- "log",
- "serde",
- "serde_json",
- "tokio 1.28.2",
  "tokio-util 0.7.8",
 ]
 
@@ -568,15 +556,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -648,9 +627,9 @@ checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 
 [[package]]
 name = "ctrlc"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7394a21d012ce5c850497fb774b167d81b99f060025fbf06ee92b9848bd97eb2"
+checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
 dependencies = [
  "nix 0.26.2",
  "windows-sys 0.48.0",
@@ -910,9 +889,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -1094,7 +1073,7 @@ dependencies = [
  "bitcoin 0.30.0",
  "bytes 1.4.0",
  "chacha20poly1305",
- "cln-grpc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cln-grpc 0.1.3 (git+https://github.com/ElementsProject/lightning.git?branch=master)",
  "hex",
  "http",
  "http-body 0.4.5",
@@ -1163,7 +1142,7 @@ dependencies = [
  "clightningrpc",
  "cln-grpc 0.1.3 (git+https://github.com/cdecker/lightning.git?branch=20230530-fix-getinfo-address-opt)",
  "cln-plugin",
- "cln-rpc 0.1.3 (git+https://github.com/cdecker/lightning.git?branch=20230530-fix-getinfo-address-opt)",
+ "cln-rpc",
  "env_logger 0.7.1",
  "futures",
  "gl-client",
@@ -1474,9 +1453,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1645,9 +1624,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
 
 [[package]]
 name = "libloading"
@@ -1661,17 +1640,20 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.114"
-source = "git+https://github.com/lightningdevkit/rust-lightning.git?rev=a7600dcd584db0c46fdcd99d71d5b271f3052892#a7600dcd584db0c46fdcd99d71d5b271f3052892"
+version = "0.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e009e1c0c21f66378b491bb40f548682138c63e09db6f3a05af59f8804bb9f4a"
 dependencies = [
  "bitcoin 0.29.2",
- "musig2",
+ "hex",
+ "regex",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.22.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning.git?rev=a7600dcd584db0c46fdcd99d71d5b271f3052892#a7600dcd584db0c46fdcd99d71d5b271f3052892"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e44b0e2822c8811470137d2339fdfe67a699b3248bb1606d1d02eb6a1e9f0a"
 dependencies = [
  "bech32",
  "bitcoin 0.29.2",
@@ -1684,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "lightning-storage-server"
 version = "0.3.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git?branch=main#d20bb7e47cfd5ac27897b181c4d56045f29cd0a4"
+source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git?branch=main#ae8d761299c13fbd665ad1ecd0fa7b727419a814"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1819,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
@@ -1878,14 +1860,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "musig2"
-version = "0.1.0"
-source = "git+https://github.com/arik-so/rust-musig2?rev=27797d7#27797d78cf64e8974e38d7f31ebb11e455015a9e"
-dependencies = [
- "bitcoin 0.29.2",
-]
 
 [[package]]
 name = "neon"
@@ -1998,7 +1972,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.8.7",
+ "mio 0.8.8",
  "walkdir",
  "winapi 0.3.9",
 ]
@@ -2063,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -2138,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
@@ -3213,7 +3187,7 @@ dependencies = [
  "autocfg",
  "bytes 1.4.0",
  "libc",
- "mio 0.8.7",
+ "mio 0.8.8",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.9",
@@ -3686,12 +3660,11 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "txoo"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d0beccb482c6106605c4eaf4d4bc4ece62b431f148a3f7c0d53a28c0aed6e7"
+checksum = "0d8d7e67ea44d2f4df67df6c91e4c2d4e199b4f4950074ccc5cb141a3be60e01"
 dependencies = [
  "bitcoin 0.29.2",
- "core2",
  "log",
  "serde",
 ]
@@ -3759,9 +3732,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3776,8 +3749,8 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vls-core"
-version = "0.2.1"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.0"
+source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3800,8 +3773,8 @@ dependencies = [
 
 [[package]]
 name = "vls-persist"
-version = "0.2.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.0"
+source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
 dependencies = [
  "hex",
  "log",
@@ -3813,8 +3786,8 @@ dependencies = [
 
 [[package]]
 name = "vls-protocol"
-version = "0.2.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.0"
+source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
 dependencies = [
  "as-any",
  "bolt-derive",
@@ -3827,8 +3800,8 @@ dependencies = [
 
 [[package]]
 name = "vls-protocol-signer"
-version = "0.2.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.0"
+source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
 dependencies = [
  "bit-vec",
  "log",


### PR DESCRIPTION
The ChainTracker changed the format for `tip` so the loading after an upgrade to v23.05 could fail to load.