### PR TITLE
vls: Switch to snapshot repository

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bolt-derive"
 version = "0.1.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "cln-grpc"
 version = "0.1.3"
-source = "git+https://github.com/ElementsProject/lightning.git?branch=master#85992e6e48a6131afee9b24d8b8f99ecd268d73e"
+source = "git+https://github.com/ElementsProject/lightning.git?branch=master#ea7d4285799358c78f61225fcab65dc411761de9"
 dependencies = [
  "anyhow",
  "bitcoin 0.29.2",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "cln-rpc"
 version = "0.1.3"
-source = "git+https://github.com/ElementsProject/lightning.git?branch=master#85992e6e48a6131afee9b24d8b8f99ecd268d73e"
+source = "git+https://github.com/ElementsProject/lightning.git?branch=master#ea7d4285799358c78f61225fcab65dc411761de9"
 dependencies = [
  "anyhow",
  "bitcoin 0.29.2",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "gl-client"
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "lightning-storage-server"
 version = "0.3.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git?branch=main#cc812116a56eec6b8a10188da4460b82e2115b0b"
+source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git?branch=main#84cabcab3ea2f2918ee0ae5e5e527ac7369b4be2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1909,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2854,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -2892,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -3745,7 +3745,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vls-core"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "vls-persist"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "hex",
  "log",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "vls-protocol"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "as-any",
  "bolt-derive",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "vls-protocol-signer"
 version = "0.9.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer?branch=2023-05-memo-approve#da6a1f64f7322ef3c2d8c94a1d7f90a9a813c86a"
+source = "git+https://gitlab.com/cdecker/vls?branch=snapshot-20230616#0d787c07a7c7049624761498af9364c46ba137b4"
 dependencies = [
  "bit-vec",
  "log",
@@ -3817,11 +3817,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 

--- a/libs/gl-client/Cargo.toml
+++ b/libs/gl-client/Cargo.toml
@@ -27,10 +27,10 @@ rcgen = { version = "0.10.0", features = ["pem", "x509-parser"]}
 tempfile = "3.3.0"
 bitcoin = "^0"
 serde = { version = "1", features = [ "derive" ] }
-vls-core = { git="https://gitlab.com/lightning-signer/validating-lightning-signer", branch="2023-05-memo-approve" }
-vls-persist = { git="https://gitlab.com/lightning-signer/validating-lightning-signer", branch="2023-05-memo-approve" }
-vls-protocol-signer = { git="https://gitlab.com/lightning-signer/validating-lightning-signer", branch="2023-05-memo-approve" }
-vls-protocol = { git="https://gitlab.com/lightning-signer/validating-lightning-signer", branch="2023-05-memo-approve" }
+vls-core = { git="https://gitlab.com/cdecker/vls", branch="snapshot-20230616" }
+vls-persist = { git="https://gitlab.com/cdecker/vls", branch="snapshot-20230616" }
+vls-protocol-signer = { git="https://gitlab.com/cdecker/vls", branch="snapshot-20230616" }
+vls-protocol = { git="https://gitlab.com/cdecker/vls", branch="snapshot-20230616" }
 serde_json = "^1.0"
 thiserror = "1"
 cln-grpc = { git = "https://github.com/ElementsProject/lightning.git", branch = "master"}

--- a/libs/gl-client/src/scheduler.rs
+++ b/libs/gl-client/src/scheduler.rs
@@ -65,6 +65,7 @@ impl Scheduler {
         signer: &Signer,
         invite_code: String,
     ) -> Result<pb::scheduler::RegistrationResponse> {
+        log::debug!("Retrieving challenge for registration");
         let challenge = self
             .client
             .clone()
@@ -74,6 +75,8 @@ impl Scheduler {
             })
             .await?
             .into_inner();
+
+        log::trace!("Got a challenge: {}", hex::encode(&challenge.challenge));
 
         let signature = signer.sign_challenge(challenge.challenge.clone())?;
         let device_cert = tls::generate_self_signed_device_cert(


### PR DESCRIPTION
The branches in the VLS repository keep disappearing, so let's archive the state that we know works, and reference those instead.