### PR TITLE
vls: Update to VLS v0.9.1rc2

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -268,8 +268,7 @@ checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
  "bitcoin_hashes 0.11.0",
- "core2",
- "hashbrown 0.8.2",
+ "bitcoinconsensus",
  "secp256k1 0.24.3",
  "serde",
 ]
@@ -299,7 +298,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 dependencies = [
- "core2",
  "serde",
 ]
 
@@ -310,6 +308,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoinconsensus"
+version = "0.20.2-0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54505558b77e0aa21b2491a7b39cbae9db22ac8b1bc543ef4600edb762306f9c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -330,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bolt-derive"
 version = "0.1.0"
-source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230619#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230620#3a016a06ca61edbaa7fc1350d5bde2ba0b9417d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -534,15 +542,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1628,17 +1627,20 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.114"
-source = "git+https://github.com/lightningdevkit/rust-lightning.git?rev=a7600dcd584db0c46fdcd99d71d5b271f3052892#a7600dcd584db0c46fdcd99d71d5b271f3052892"
+version = "0.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e009e1c0c21f66378b491bb40f548682138c63e09db6f3a05af59f8804bb9f4a"
 dependencies = [
  "bitcoin 0.29.2",
- "musig2",
+ "hex",
+ "regex",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.22.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning.git?rev=a7600dcd584db0c46fdcd99d71d5b271f3052892#a7600dcd584db0c46fdcd99d71d5b271f3052892"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e44b0e2822c8811470137d2339fdfe67a699b3248bb1606d1d02eb6a1e9f0a"
 dependencies = [
  "bech32",
  "bitcoin 0.29.2",
@@ -1863,14 +1865,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "musig2"
-version = "0.1.0"
-source = "git+https://github.com/arik-so/rust-musig2?rev=27797d7#27797d78cf64e8974e38d7f31ebb11e455015a9e"
-dependencies = [
- "bitcoin 0.29.2",
-]
 
 [[package]]
 name = "neon"
@@ -3661,12 +3655,11 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "txoo"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d0beccb482c6106605c4eaf4d4bc4ece62b431f148a3f7c0d53a28c0aed6e7"
+checksum = "0d8d7e67ea44d2f4df67df6c91e4c2d4e199b4f4950074ccc5cb141a3be60e01"
 dependencies = [
  "bitcoin 0.29.2",
- "core2",
  "log",
  "serde",
 ]
@@ -3751,8 +3744,8 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vls-core"
-version = "0.2.1"
-source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230619#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.1-rc.2"
+source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230620#3a016a06ca61edbaa7fc1350d5bde2ba0b9417d6"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3775,8 +3768,8 @@ dependencies = [
 
 [[package]]
 name = "vls-persist"
-version = "0.2.0"
-source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230619#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.1-rc.2"
+source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230620#3a016a06ca61edbaa7fc1350d5bde2ba0b9417d6"
 dependencies = [
  "hex",
  "log",
@@ -3788,8 +3781,8 @@ dependencies = [
 
 [[package]]
 name = "vls-protocol"
-version = "0.2.0"
-source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230619#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.1-rc.2"
+source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230620#3a016a06ca61edbaa7fc1350d5bde2ba0b9417d6"
 dependencies = [
  "as-any",
  "bolt-derive",
@@ -3802,8 +3795,8 @@ dependencies = [
 
 [[package]]
 name = "vls-protocol-signer"
-version = "0.2.0"
-source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230619#a1800748546bd2ada73fb49aefefa6a7025e4fbd"
+version = "0.9.1-rc.2"
+source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230620#3a016a06ca61edbaa7fc1350d5bde2ba0b9417d6"
 dependencies = [
  "bit-vec",
  "log",

--- a/libs/gl-client/Cargo.toml
+++ b/libs/gl-client/Cargo.toml
@@ -27,10 +27,10 @@ rcgen = { version = "0.10.0", features = ["pem", "x509-parser"]}
 tempfile = "3.3.0"
 bitcoin = "^0"
 serde = { version = "1", features = [ "derive" ] }
-vls-core = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230619" }
-vls-persist = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230619" }
-vls-protocol-signer = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230619" }
-vls-protocol = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230619" }
+vls-core = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230620" }
+vls-persist = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230620" }
+vls-protocol-signer = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230620" }
+vls-protocol = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230620" }
 serde_json = "^1.0"
 thiserror = "1"
 cln-grpc = { git = "https://github.com/ElementsProject/lightning.git", branch = "master"}


### PR DESCRIPTION
Apparently we dropped a backward compatibility shim while catching up with VLS `main`.