### PR TITLE
Fix empty preimage

### DIFF
--- a/libs/gl-plugin/src/responses.rs
+++ b/libs/gl-plugin/src/responses.rs
@@ -135,7 +135,10 @@ pub struct ListPaysPay {
     // msatoshi is renamed amount_msat
     pub amount_msat: Option<MSat>,
     pub amount_sent_msat: MSat,
+
+    #[serde(rename = "preimage")]
     pub payment_preimage: Option<String>,
+
     pub status: String,
 }
 


### PR DESCRIPTION
We get empty `preimage` for payments retrieved via `list_payments` endpoint.
By observing the node client `list_pays` endpoint it seems that the value there is correct but renamed differently causing the deserialization result in empty string.
I don't have a way to test it currently but pretty sure this will fix it.