### PR TITLE
Allow partial request context parsing

### DIFF
--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -565,8 +565,7 @@ fn decode_request(r: crate::pb::PendingRequest) -> Result<model::Request> {
     let payload = &r.request[5..];
 
     Ok(crate::signer::model::cln::decode_request(&r.uri, payload)
-        .or_else(|_| crate::signer::model::greenlight::decode_request(&r.uri, payload))
-        .unwrap())
+        .or_else(|_| crate::signer::model::greenlight::decode_request(&r.uri, payload))?)
 }
 
 /// A `(request, response)`-tuple passed to the scheduler to allow

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -564,8 +564,8 @@ fn decode_request(r: crate::pb::PendingRequest) -> Result<model::Request> {
     assert_eq!(r.request[0], 0u8);
     let payload = &r.request[5..];
 
-    Ok(crate::signer::model::cln::decode_request(&r.uri, payload)
-        .or_else(|_| crate::signer::model::greenlight::decode_request(&r.uri, payload))?)
+    crate::signer::model::cln::decode_request(&r.uri, payload)
+        .or_else(|_| crate::signer::model::greenlight::decode_request(&r.uri, payload))
 }
 
 /// A `(request, response)`-tuple passed to the scheduler to allow

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -233,7 +233,8 @@ impl Signer {
                 .into_iter()
                 .filter_map(|r| r.ok())
                 .map(|r| decode_request(r))
-                .collect::<Result<Vec<model::Request>>>()?;
+                .filter_map(|r| r.ok())
+                .collect::<Vec<model::Request>>();
 
             // TODO: Decode requests and reconcile them with the changes
             use auth::Authorizer;

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -233,7 +233,13 @@ impl Signer {
                 .into_iter()
                 .filter_map(|r| r.ok())
                 .map(|r| decode_request(r))
-                .filter_map(|r| r.ok())
+                .filter_map(|r| match r {
+                    Ok(r) => Some(r),
+                    Err(e) => {
+                        log::error!("Unable to decode request in context: {}", e);
+                        None
+                    }
+                })
                 .collect::<Vec<model::Request>>();
 
             // TODO: Decode requests and reconcile them with the changes


### PR DESCRIPTION
If we have a mismatch between the signer and the node, specifically with the node older than the client, we can end up in a situation where the parsing of the context fails, despite not actually being fatal, and then getting stuck until the node restarts.

This now complains about any failure to parse the context, but will still go ahead and try reconciling for the E2E verification. This works because the failure in #193 was a read-only request and not even required in the context.

This PR is part 1 of the proposed solutions in #193.