### PR TITLE
ci: Update the binary tester image

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -70,7 +70,7 @@ jobs:
       if: matrix.target != 'ppc64' && matrix.target != 'x86_64' && matrix.target != 'i686'
       with:
         arch: ${{ matrix.target }}
-        distro: ubuntu20.04
+        distro: ubuntu22.04
         githubToken: ${{ github.token }}
         install: |
           apt-get update


### PR DESCRIPTION
For some reason the armv7 image is using glibc 2.33 which wasn't available in Ubuntu 20.04. This updates the image to use ubuntu 22.04.