### PR TITLE
libs: Bump client bindings version for publication

### DIFF
--- a/libs/gl-client-js/Cargo.toml
+++ b/libs/gl-client-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-client-js"
-version = "0.1.9"
+version = "0.1.10"
 license = "MIT"
 edition = "2018"
 

--- a/libs/gl-client-js/package.json
+++ b/libs/gl-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gl-client",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Greenlight is non-custodial lightning-as-a-service. Your users hold their keys, while we take care of everything else. These are the JS client bindings.",
   "main": "index.js",
   "files": [

--- a/libs/gl-client-py/Cargo.toml
+++ b/libs/gl-client-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-client-py"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2018"
 license = "MIT"
 

--- a/libs/gl-client-py/pyproject.toml
+++ b/libs/gl-client-py/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
 
 [tool.poetry]
 name = "gl-client"
-version = "0.1.8"
+version = "0.1.9"
 description = ""
 authors = ["Christian Decker <decker@blockstream.com>"]
 license = "MIT"

--- a/libs/gl-client/Cargo.toml
+++ b/libs/gl-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-client"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
We want to ship some of the recent changes to users:

 - #195 
 - #194 
 - #190 
 - #189 
 - #182 