### PR TITLE
Pin lightning-storage-server to our snapshot

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "lightning-storage-server"
 version = "0.3.0"
-source = "git+https://gitlab.com/lightning-signer/validating-lightning-signer.git?branch=main#84cabcab3ea2f2918ee0ae5e5e527ac7369b4be2"
+source = "git+https://gitlab.com/cdecker/vls?tag=snapshot-20230620#3a016a06ca61edbaa7fc1350d5bde2ba0b9417d6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -5,6 +5,7 @@ codegen-units = 1
 panic = "abort"
 
 [workspace]
+resolver = "2"
 members = [
   "gl-client",
   "gl-client-py",

--- a/libs/gl-plugin/Cargo.toml
+++ b/libs/gl-plugin/Cargo.toml
@@ -33,7 +33,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tonic = { version = "^0.8", features = ["tls", "transport"] }
 tower = { version = "0.4" }
-lightning-storage-server = { git="https://gitlab.com/lightning-signer/validating-lightning-signer.git", branch="main" }
+lightning-storage-server = { git="https://gitlab.com/cdecker/vls", tag="snapshot-20230620" }
 sled = "*"
 hyper = "0.14.23"
 base64 = "0.13.1"


### PR DESCRIPTION
We use VLS through a tag in a forked repository so we're in control of when we deploy changes. The lss was not pinned to that tag.