### PR TITLE
signer: Introduce an Error enum to selectively react to errors

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
  "http",
  "http-body 0.4.5",
  "log",
- "pin-project 1.1.0",
+ "pin-project 0.4.30",
  "prost 0.11.9",
  "rcgen",
  "ring",


### PR DESCRIPTION
Errors when talking to the node or the scheduler are varied, and our reaction to them needs to be as well. So let's introduce a custom error type, that we can then use to differentiate connection issues, from disconnections, and from app level errors.

In particular we want to go back to the scheduler if we lost contact while streaming, but not if there is an app level error.