### PR TITLE
Drop support for python versions that are EOL

### DIFF
--- a/libs/gl-client-py/pyproject.toml
+++ b/libs/gl-client-py/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 black = "^23.1.0"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4"
+python = ">=3.9,<4"
 grpcio = "^1.56"
 pyln-grpc-proto = "^0.1"
 

--- a/libs/gl-testing/pyproject.toml
+++ b/libs/gl-testing/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 cryptography = ">=36.0.1,<37.0.0"
 ephemeral-port-reserve = "^1.1.4"
 sh = "^1.14.2"

--- a/tools/glcli/pyproject.toml
+++ b/tools/glcli/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Christian Decker <decker@blockstream.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 click = "^8"
 grpcio = "^1.46.1"
 protobuf = "^3.20.1"


### PR DESCRIPTION
The libraries are not working for python 3.7 because we are using the `SupportsIndex` type.

Version 3.7 and 3.8 are also end-of-life.

Resolves
[216](https://github.com/Blockstream/greenlight/issues/216)