### PR TITLE
client: Add keepalive to signer, scheduler and node connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build-self: ensure-docker
 	(cd libs; cargo build --all)
 	(cd libs/gl-client-py && \
 	maturin build --strip && \
-	pip install --force-reinstall /tmp/target/wheels/gl_client*.whl)
+	pip install --force-reinstall ${CARGO_TARGET_DIR}/wheels/gl_client*.whl)
 	pip install coverage
 
 check-self: ensure-docker
@@ -58,9 +58,9 @@ docker-shell:
 	  --net=host \
 	  --rm \
           --cap-add=SYS_PTRACE \
-	  -e TMPDIR=/tmp/gltesting/ \
+	  -e TMPDIR=/tmp/gltesting/tmp \
 	  -v /tmp/gltesting/:/tmp/gltesting \
-          -e CARGO_TARGET_DIR=/tmp/target \
+          -e CARGO_TARGET_DIR=/tmp/gltesting/target \
           -v /tmp/target:/tmp/target \
           -v /tmp/gl-cargo-registry:/root/.cargo/registry/ \
 	  -v ${REPO_ROOT}:/repo \

--- a/docs/src/about/changelog.md
+++ b/docs/src/about/changelog.md
@@ -13,3 +13,27 @@
    incorrect context use. Now we return errors as they are emitted.
  - The scheduler no longer allows creating `regtest` nodes, since they
    are unusable without a faucet to get coins for it.
+
+### July
+ - The `gl-plugin` will now wait for both the initial gossip sync and
+   the reconnection to the peers to complete, before allowing `pay`
+   through. This cuts down on spurious payment failures due to missing
+   peers or incomplete network view for routing.
+ - An issue concerning reconnecting to peers, if the signer attaches
+   before the underlying JSON-RPC has become available has been
+   fixed. This issue would cause peers to remain disconnected despite
+   a signer being attached. [#210][pr210] & [#204][pr204]
+ - The `gl-client` library and the language bindings have keepalive
+   messages enabled, with a timeout of 90 seconds. This ensures that
+   clients and signers that have been silently disconnected, e.g., by
+   suspending the device or losing network connectivity, will notice
+   and reconnect. [#220][pr220]
+ - The Node Domain has been enabled. This means that ever node now has
+   a unique URL at which the node can always be reached, without
+   having to explicitly schedule it first. This allows bypassing of
+   the scheduler, reducing the time required to start and connect to a
+   node.
+
+[pr204]: https://github.com/Blockstream/greenlight/pull/204
+[pr210]: https://github.com/Blockstream/greenlight/pull/210
+[pr220]: https://github.com/Blockstream/greenlight/pull/220

--- a/libs/gl-client/build.rs
+++ b/libs/gl-client/build.rs
@@ -2,8 +2,18 @@ const NOBODY_CRT: &'static str = "../../tls/users-nobody.pem";
 const NOBODY_KEY: &'static str = "../../tls/users-nobody-key.pem";
 
 use std::env::var;
+use std::process::Command;
 
 fn main() {
+    // It's a lot easier to help users if we have the exact version of
+    // the Rust bindings that were used.
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
     // Either both are set or none is :-) We set an env-var for
     // `rustc` to pick up and include using `env!`.
     let vars = match (var("GL_CUSTOM_NOBODY_KEY"), var("GL_CUSTOM_NOBODY_CERT")) {

--- a/libs/gl-client/src/lib.rs
+++ b/libs/gl-client/src/lib.rs
@@ -50,6 +50,8 @@ pub mod utils {
     }
 }
 
+use std::time::Duration;
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -59,3 +61,6 @@ pub enum Error {
 }
 
 pub use lightning_signer::bitcoin;
+
+pub(crate) const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+pub(crate) const TCP_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(90);

--- a/libs/gl-client/src/lib.rs
+++ b/libs/gl-client/src/lib.rs
@@ -46,7 +46,7 @@ pub mod utils {
 
     pub fn scheduler_uri() -> String {
         std::env::var("GL_SCHEDULER_GRPC_URI")
-            .unwrap_or_else(|_| "https://scheduler.gl.blckstrm.com:2601".to_string())
+            .unwrap_or_else(|_| "https://scheduler.gl.blckstrm.com".to_string())
     }
 }
 

--- a/libs/gl-client/src/node/mod.rs
+++ b/libs/gl-client/src/node/mod.rs
@@ -101,10 +101,10 @@ impl Node {
         };
 
         let chan = tonic::transport::Endpoint::from_shared(node_uri.to_string())?
-            .tcp_keepalive(Some(Duration::from_secs(10)))
             .tls_config(tls.inner)?
-            .http2_keep_alive_interval(Duration::from_secs(10))
-            .keep_alive_timeout(Duration::from_secs(60))
+            .tcp_keepalive(Some(crate::TCP_KEEPALIVE))
+            .http2_keep_alive_interval(crate::TCP_KEEPALIVE)
+            .keep_alive_timeout(crate::TCP_KEEPALIVE_TIMEOUT)
             .keep_alive_while_idle(true)
             .connect_lazy();
         let chan = ServiceBuilder::new().layer(layer).service(chan);

--- a/libs/gl-client/src/scheduler.rs
+++ b/libs/gl-client/src/scheduler.rs
@@ -30,10 +30,10 @@ impl Scheduler {
     ) -> Result<Scheduler> {
         debug!("Connecting to scheduler at {}", uri);
         let channel = tonic::transport::Endpoint::from_shared(uri)?
-            .tcp_keepalive(Some(Duration::from_secs(10)))
             .tls_config(tls.inner.clone())?
-            .http2_keep_alive_interval(Duration::from_secs(10))
-            .keep_alive_timeout(Duration::from_secs(60))
+            .tcp_keepalive(Some(crate::TCP_KEEPALIVE))
+            .http2_keep_alive_interval(crate::TCP_KEEPALIVE)
+            .keep_alive_timeout(crate::TCP_KEEPALIVE_TIMEOUT)
             .keep_alive_while_idle(true)
             .connect_lazy();
 

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -27,6 +27,7 @@ mod auth;
 pub mod model;
 
 const VERSION: &str = "v23.05";
+const GITHASH: &str = env!("GIT_HASH");
 
 #[derive(Clone)]
 pub struct Signer {
@@ -74,7 +75,7 @@ impl Signer {
         use lightning_signer::signer::ClockStartingTimeFactory;
         use lightning_signer::util::clock::StandardClock;
 
-        info!("Initializing signer for {VERSION} (VLS)");
+        info!("Initializing signer for {VERSION} ({GITHASH}) (VLS)");
         let mut sec: [u8; 32] = [0; 32];
         sec.copy_from_slice(&secret[0..32]);
 


### PR DESCRIPTION
Allows us to passively detect that we lost a connection after 90s. While not quite usable for interactive scenarios (signer in keep alive timeout, client is waiting on signatures), it is useful for the standard case where the signer lost the connection while waiting for the node to get scheduled.

A deeper integration with the host's sleep state, restarting the signer when we come back from suspension for example, can be a complementary technique to address those interactive scenarios.

Closes #209