### PR TITLE
gci: Add docker-check-self run

### DIFF
--- a/.github/workflows/check-self.yml
+++ b/.github/workflows/check-self.yml
@@ -1,0 +1,26 @@
+name: Check Self
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+  workflow_dispatch:
+
+jobs:
+  linux:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        push: false
+        tags: blockstream/glci
+        context: libs/gl-testing/
+    - name: Check Self
+      run: make docker-check-self

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - synchronize
+      - opened
   workflow_dispatch:
 
 concurrency:

--- a/libs/gl-testing/Dockerfile
+++ b/libs/gl-testing/Dockerfile
@@ -17,7 +17,7 @@ ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
 
 # Some variables to fix python's absolutely horrendous grpcio
 # package. Forking in the process seems to get it really confused.
-ENV GRPC_ENABLE_FORK_SUPPORT=false
+ENV GRPC_ENABLE_FORK_SUPPORT=1
 ENV GRPC_POLL_STRATEGY=poll
 
 
@@ -65,7 +65,7 @@ RUN python3 -m pip install -U \
 ADD . /repo
 WORKDIR /repo
 
-RUN make -j $(proc) cln
+RUN make cln
 
 RUN (cd /repo/libs/gl-client && cargo build --release) && \
     (cd /repo/libs/gl-client-py && maturin build --release --strip --compatibility manylinux_2_28) && \


### PR DESCRIPTION
We were not running the self-checks on CI, we do now for PRs.
