### PR TITLE
Install jq to fix make-clean

### DIFF
--- a/libs/gl-testing/Dockerfile
+++ b/libs/gl-testing/Dockerfile
@@ -106,6 +106,7 @@ RUN apt-get update && apt-get install -qqy \
     socat \
     unzip \
     wget \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Enumerate all CLN version we want `gl-testing` to find.


### PR DESCRIPTION
If you run `make clean` inside a `make docker-shell` the operation fails. It appears `jq` is missing in the docker-image