### PR TITLE
Run unit tests in CI

### DIFF
--- a/.github/workflows/rust-unit.yml
+++ b/.github/workflows/rust-unit.yml
@@ -1,0 +1,24 @@
+name: Rust Unit Test
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+  workflow_dispatch:
+  merge_group:
+
+jobs:
+  unit_test:
+    name: Rust unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: arduino/setup-protoc@v2
+        with:
+            version: "23.2"  # Fixed since we mount the path below
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: (cd libs; cargo test)

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ build-self: ensure-docker
 	(cd libs; cargo build --all)
 	(cd libs/gl-client-py && python3 -m maturin develop)
 
+check-all: check-self check-self-gl-client check-py check-js
+
 check-self: ensure-docker
 	PYTHONPATH=/repo/libs/gl-testing \
 	pytest -vvv \
@@ -101,6 +103,13 @@ docker-check-self:
 	  --rm \
 	  -v ${REPO_ROOT}:/repo \
 	  gltesting make build-self check-self
+
+docker-check-all:
+	docker run \
+	  -t \
+	  --rm \
+	  -v ${REPO_ROOT}:/repo \
+	  gltesting make build-self check-all
 
 docker-check:
 	docker run \

--- a/libs/gl-client/Makefile
+++ b/libs/gl-client/Makefile
@@ -3,3 +3,6 @@ check-rs:
 
 clean-rs:
 	cd libs; cargo clean
+
+check-self-gl-client:
+	(cd libs/gl-client; cargo test)


### PR DESCRIPTION
Ensure all unit-tests are run on `CI`.

I have created a new action for this purpose. The action installs rust, protoc and runs all unit-tests defined in the `lib` folder.

I have also introduced a `make check-all` which can be used to run all tests locally.

**TODO**

- [x]  Fix the broken unit-test

The work to run the python tests is tackled in another MR