### PR TITLE
Add mypy-protobuf to the dev dependencies

### DIFF
--- a/libs/gl-client-py/Makefile
+++ b/libs/gl-client-py/Makefile
@@ -8,9 +8,10 @@ endif
 DIR=${REPO}/libs/gl-client-py
 PYVERSION=$(shell cd libs && cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "gl-client-py") | .version')
 PYDIR=${REPO}/libs/gl-client-py
+PROTODIR=${REPO}/libs/proto
 
 PYPROTOC_OPTS = \
-	-Ilibs/proto \
+	-I${PROTODIR} \
 	--python_out=${PYDIR}/glclient \
 	--grpc_python_out=${PYDIR}/glclient \
 	--experimental_allow_proto3_optional \
@@ -23,9 +24,9 @@ PYPROTOS = \
 	${PYDIR}/glclient/scheduler_pb2_grpc.py
 
 PROTOSRC = \
-	libs/proto/scheduler.proto \
-	libs/proto/greenlight.proto \
-	libs/proto/node.proto
+	${PROTODIR}/scheduler.proto \
+	${PROTODIR}/greenlight.proto \
+	${PROTODIR}/node.proto
 
 GENALL += ${PYPROTOS}
 
@@ -41,7 +42,7 @@ check-py:
 	cd libs/gl-client-py; pytest tests -n $(shell nproc)
 
 clean-py:
-	rm -f ${PROTOS} ${PYDIR}/build ${PYDIR}/dist
+	rm -f ${PYPROTOS} ${PYDIR}/build ${PYDIR}/dist
 
 test: build
 	virtualenv .tmpenv --python=$(which python3) --download --always-copy --clear

--- a/libs/gl-client-py/pyproject.toml
+++ b/libs/gl-client-py/pyproject.toml
@@ -20,9 +20,10 @@ packages = [
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.1.0"
+mypy-protobuf = "^3.5"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4"
+python = ">=3.8,<4"
 grpcio = ">=1.56"
 pyln-grpc-proto = "^0.1"
 


### PR DESCRIPTION
This PR adds the following two changes:
- Add `mypy-protobuf` to the `gl-client-py` dev dependencies so that we can compile the grpc files from a poetry shell.
- Improve the `Makefile` targets `clean-py` and `pygrpc` to allow them to be called from the top dir as well as from within `gl-client-py`