### PR TITLE
Extend the Invoice request message of the plugin wrapper

### DIFF
--- a/libs/gl-plugin/src/node/wrapper.rs
+++ b/libs/gl-plugin/src/node/wrapper.rs
@@ -66,7 +66,7 @@ impl Node for WrappedNodeServer {
                         "could not convert protobuf request into JSON-RPC request: {:?}",
                         e.to_string()
                     ),
-                ))
+                ));
             }
         };
         pbreq.dev_routes = hints.map(|v| {

--- a/libs/gl-plugin/src/requests.rs
+++ b/libs/gl-plugin/src/requests.rs
@@ -110,16 +110,21 @@ pub struct CloseChannel {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Invoice {
-    #[serde(rename = "msatoshi")]
-    pub amount: Amount,
-    pub label: String,
+    pub amount_msat: cln_rpc::primitives::AmountOrAny,
     pub description: String,
+    pub label: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exposeprivatechannels: Option<Vec<String>>,
-
+    pub expiry: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallbacks: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preimage: Option<String>,
-
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cltv: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deschashonly: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exposeprivatechannels: Option<Vec<String>>,
     #[serde(rename = "dev-routes", skip_serializing_if = "Option::is_none")]
     pub dev_routes: Option<Vec<Vec<RoutehintHopDev>>>,
 }

--- a/libs/gl-testing/tests/test_node.py
+++ b/libs/gl-testing/tests/test_node.py
@@ -110,6 +110,26 @@ def test_node_invoice_preimage(clients):
     assert i.payment_hash.hex() == expected
 
 
+def test_node_invoice_expiration(clients):
+    """Test that we can set the invoice expiry
+
+    The invoice should expire after the set expiry.
+    """
+    c1: Client = clients.new()
+    c1.register()
+    s = c1.signer().run_in_thread()
+    n1 = c1.node()
+
+    now = int(time.time())
+    res = n1.invoice(
+        amount_msat=clnpb.AmountOrAny(any=True),
+        description="desc",
+        label="lbl",
+        expiry=100,
+    )
+    assert now <= res.expires_at <= now + 160
+    
+
 def test_cln_grpc_interface(clients):
     """Test that we can talk to the cln-grpc interface.
 


### PR DESCRIPTION
Due to greenlight.proto - which we need to retire at some point - we were missing some fields of the invoice rcp request message. This adds all fields that are set by cln_grpc and extends the conversion traits.

Resolves #255 