### PR TITLE
Add Rule sets for Rune creation

### DIFF
--- a/libs/gl-client-py/glclient/__init__.py
+++ b/libs/gl-client-py/glclient/__init__.py
@@ -180,6 +180,15 @@ class Node(object):
         return res.FromString(
             bytes(self.inner.call(uri, bytes(req)))
         )
+    
+    def list_peer_channels(self) -> clnpb.ListpeerchannelsResponse:
+        uri = "/cln.Node/ListPeerChannels"
+        req = clnpb.ListpeerchannelsRequest().SerializeToString()
+        res = clnpb.ListpeerchannelsResponse
+
+        return res.FromString(
+            bytes(self.inner.call(uri, bytes(req)))
+        )
 
     def list_closed_channels(self) -> clnpb.ListclosedchannelsResponse:
         uri = "/cln.Node/ListClosedChannels"

--- a/libs/gl-client/src/lib.rs
+++ b/libs/gl-client/src/lib.rs
@@ -69,3 +69,5 @@ pub use lightning_signer::lightning_invoice;
 
 pub(crate) const TCP_KEEPALIVE: Duration = Duration::from_secs(5);
 pub(crate) const TCP_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(90);
+
+pub mod runes;

--- a/libs/gl-client/src/runes.rs
+++ b/libs/gl-client/src/runes.rs
@@ -1,0 +1,171 @@
+use runeauth::{Alternative, Condition, Restriction, Rune, RuneError};
+
+/// Represents an entity that can provide restrictions.
+///
+/// The `Restrictor` trait should be implemented by types that are able to
+/// produce a list of `Restriction`s. The `generate` method returns a `Result`
+/// containing a vector of `Restriction`s or a `RuneError` in case of any error.
+pub trait Restrictor {
+    /// Retrieves the restrictions associated with the current instance.
+    ///
+    /// # Returns
+    /// A `Result` containing a `Vec` of `Restriction`s. In the event of
+    /// failure, returns a `RuneError`.
+    fn generate(self) -> Result<Vec<Restriction>, RuneError>;
+}
+
+/// A factory responsible for carving runes.
+///
+/// `RuneFactory` provides utility functions to manipulate and produce runes
+/// with certain characteristics, such as additional restrictions.
+pub struct RuneFactory;
+
+impl RuneFactory {
+    /// Combines an original `Rune` with a list of restricters,
+    /// and produces a new rune in base64 format.
+    ///
+    /// # Parameters
+    /// - `origin`: A reference to the original `Rune` that will serve as the
+    /// base.
+    /// - `append`: A `Vec` containing entities that implement the `Restrictor`
+    /// trait.
+    ///
+    /// # Returns
+    /// A `Result` containing a `String` representing the carved rune in base64 format.
+    /// In the event of any failure during the carving process, returns a `RuneError`.
+    pub fn carve<T: Restrictor + Copy>(origin: &Rune, append: &[T]) -> Result<String, RuneError> {
+        let restrictions = append.into_iter().try_fold(Vec::new(), |mut acc, res| {
+            let mut r = res.generate()?;
+            acc.append(&mut r);
+            Ok(acc)
+        })?;
+
+        let mut originc = origin.clone();
+        restrictions.into_iter().for_each(|r| {
+            // Changes are applied in place, as well as returned, so
+            // this is ok.
+            let _ = originc.add_restriction(r);
+        });
+
+        Ok(originc.to_base64())
+    }
+}
+
+/// Predefined rule sets to generate `Restriction`s from.
+#[derive(Clone, Copy)]
+pub enum DefRules<'a> {
+    /// Represents a rule set where only read operations are allowed. This
+    /// translates to a `Restriction` that is "method^Get|method^List".
+    ReadOnly,
+    /// Represents a rule set where only the `pay` method is allowed. This
+    /// translates to a `Restriction` that is "method=pay".
+    Pay,
+    /// A special rule that adds the alternatives of the given `DefRules`
+    /// in a disjunctive set. Example: Add(vec![ReadOnly, Pay]) translates
+    /// to a `Restriction` that is "method^Get|method^List|method=pay".
+    Add(&'a [DefRules<'a>]),
+}
+
+impl<'a> Restrictor for DefRules<'a> {
+    /// Generate the actual `Restriction` entities based on the predefined rule
+    /// sets.
+    ///
+    /// # Returns
+    /// A `Result` containing a vector of `Restriction` entities or a `RuneError`
+    /// if there's any error while generating the restrictions.
+    fn generate(self) -> Result<Vec<Restriction>, RuneError> {
+        match self {
+            DefRules::ReadOnly => {
+                let a: Vec<Restriction> = vec![Restriction::new(vec![
+                    alternative("method", Condition::BeginsWith, "Get").unwrap(),
+                    alternative("method", Condition::BeginsWith, "List").unwrap(),
+                ])
+                .unwrap()];
+                Ok(a)
+            }
+            DefRules::Pay => {
+                let a =
+                    vec![Restriction::new(vec![
+                        alternative("method", Condition::Equal, "pay").unwrap()
+                    ])
+                    .unwrap()];
+                Ok(a)
+            }
+            DefRules::Add(rules) => {
+                let alt_set =
+                    rules
+                        .into_iter()
+                        .try_fold(Vec::new(), |mut acc: Vec<Alternative>, rule| {
+                            let mut alts = rule
+                                .generate()?
+                                .into_iter()
+                                .flat_map(|r| r.alternatives)
+                                .collect();
+                            acc.append(&mut alts);
+                            Ok(acc)
+                        })?;
+                let a = vec![Restriction::new(alt_set)?];
+                Ok(a)
+            }
+        }
+    }
+}
+
+/// Creates an `Alternative` based on the provided field, condition, and value.
+///
+/// This function is a shorthand for creating new `Alternative` entities
+/// without having to manually wrap field and value into `String`.
+///
+/// # Parameters
+/// - `field`: The field on which the alternative is based.
+/// - `cond`: The condition to check against the field.
+/// - `value`: The value to match with the condition against the field.
+///
+/// # Returns
+///
+/// A result containing the created `Alternative` or a `RuneError` if there's
+/// any error in the creation.
+fn alternative(field: &str, cond: Condition, value: &str) -> Result<Alternative, RuneError> {
+    Alternative::new(field.to_string(), cond, value.to_string(), false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DefRules, RuneFactory};
+    use base64::{engine::general_purpose, Engine as _};
+    use runeauth::Rune;
+
+    #[test]
+    fn test_carve_readonly_rune() {
+        let seed = [0; 32];
+        let mr = Rune::new_master_rune(&seed, vec![], None, None).unwrap();
+
+        // Carve a new rune from the master rune with given restrictions.
+        let carved = RuneFactory::carve(&mr, &[DefRules::ReadOnly]).unwrap();
+
+        let carved_byt = general_purpose::URL_SAFE.decode(&carved).unwrap();
+        let carved_restr = String::from_utf8(carved_byt[32..].to_vec()).unwrap(); // Strip off the authcode to inspect the restrictions.
+        assert_eq!(carved_restr, *"method^Get|method^List");
+
+        let carved_rune = Rune::from_base64(&carved).unwrap();
+        assert!(mr.is_authorized(&carved_rune));
+    }
+
+    #[test]
+    fn test_carve_disjunction_rune() {
+        let seed = [0; 32];
+        let mr = Rune::new_master_rune(&seed, vec![], None, None).unwrap();
+
+        // Carve a new rune from the master rune with given restrictions.
+        let carved =
+            RuneFactory::carve(&mr, &[DefRules::Add(&[DefRules::ReadOnly, DefRules::Pay])])
+                .unwrap();
+
+        let carved_byt = general_purpose::URL_SAFE.decode(&carved).unwrap();
+        let carved_restr = String::from_utf8(carved_byt[32..].to_vec()).unwrap(); // Strip off the authcode to inspect the restrictions.
+        assert_eq!(carved_restr, *"method^Get|method^List|method=pay");
+
+        let carved_rune = Rune::from_base64(&carved).unwrap();
+        assert!(mr.is_authorized(&carved_rune));
+    }
+}

--- a/libs/gl-client/src/runes.rs
+++ b/libs/gl-client/src/runes.rs
@@ -161,6 +161,8 @@ pub struct Context {
     pub method: String,
     // The public key associated with the request.
     pub pubkey: String,
+    // The unique id.
+    pub unique_id: String,
     // The timestamp associated with the request.
     pub time: SystemTime,
     // Todo (nepet): Add param field that uses enum or serde to store the params  of a call.
@@ -180,6 +182,7 @@ impl Check for Context {
     /// * `Ok(())` if the check is successful, an `Err` containing a `RuneError` otherwise.
     fn check_alternative(&self, alt: &Alternative) -> anyhow::Result<(), RuneError> {
         let value = match alt.get_field().as_str() {
+            "" => self.unique_id.clone(),
             "method" => self.method.clone(),
             "pubkey" => self.pubkey.clone(),
             "time" => self
@@ -322,6 +325,7 @@ mod tests {
             method: String::new(),
             pubkey: String::from("020000000000000000"),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r1.are_restrictions_met(ctx).is_ok());
         // Check with method="ListFunds", pubkey=020000000000000000
@@ -329,6 +333,7 @@ mod tests {
             method: String::from("ListFunds"),
             pubkey: String::from("020000000000000000"),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r1.are_restrictions_met(ctx).is_ok());
         // Check with method="GetInfo", pubkey=""
@@ -336,6 +341,7 @@ mod tests {
             method: String::from("GetInfo"),
             pubkey: String::new(),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r2.are_restrictions_met(ctx).is_ok());
         // Check with method="GetInfo", pubkey="020000000000000000"
@@ -343,6 +349,7 @@ mod tests {
             method: String::from("GetInfo"),
             pubkey: String::from("020000000000000000"),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r2.are_restrictions_met(ctx).is_ok());
         // Check with method="GetInfo", pubkey=""
@@ -350,6 +357,7 @@ mod tests {
             method: String::from("GetInfo"),
             pubkey: String::new(),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r3.are_restrictions_met(ctx).is_ok());
         // Check with method="", pubkey="020000"
@@ -357,6 +365,7 @@ mod tests {
             method: String::new(),
             pubkey: String::from("020000000000000000"),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r4.are_restrictions_met(ctx).is_ok());
 
@@ -366,6 +375,7 @@ mod tests {
             method: String::from("ListFunds"),
             pubkey: String::from("030000"),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r1.are_restrictions_met(ctx).is_err());
         // Check with method="ListFunds", pubkey=030000, wrong method.
@@ -373,6 +383,7 @@ mod tests {
             method: String::from("ListFunds"),
             pubkey: String::from("030000"),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r2.are_restrictions_met(ctx).is_err());
         // Check with pubkey=030000, pubkey present.
@@ -380,6 +391,7 @@ mod tests {
             method: String::new(),
             pubkey: String::from("030000"),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r3.are_restrictions_met(ctx).is_err());
         // Check with method="GetInfo", method present.
@@ -387,6 +399,7 @@ mod tests {
             method: String::from("GetInfo"),
             pubkey: String::new(),
             time: SystemTime::now(),
+            unique_id: String::new(),
         };
         assert!(r4.are_restrictions_met(ctx).is_err());
     }

--- a/libs/gl-testing/tests/test_node.py
+++ b/libs/gl-testing/tests/test_node.py
@@ -81,7 +81,8 @@ def test_node_network(node_factory, clients, bitcoind):
     bitcoind.generate_block(6, wait_for_mempool=1)
 
     # Now wait for the channel to confirm
-    wait_for(lambda: gl1.list_peers().peers[0].channels[0].state == 'CHANNELD_NORMAL')
+    wait_for(lambda: len(gl1.list_peer_channels().channels) > 0)
+    wait_for(lambda: gl1.list_peer_channels().channels[0].state ==  2) # CHANNELD_NORMAL
     wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2)
 
     inv = gl1.invoice(
@@ -163,7 +164,10 @@ def test_node_invoice_amountless(bitcoind, node_factory, clients):
         amount=clnpb.AmountOrAll(amount=clnpb.Amount(msat=10**9))
     )
     bitcoind.generate_block(6, wait_for_mempool=1)
-    wait_for(lambda: gl1.list_peers().peers[0].channels[0].state == 2)  # CHANNELD_NORMAL
+    
+    # the channels array is optional
+    wait_for(lambda: len(gl1.list_peer_channels().channels) > 0)
+    wait_for(lambda: gl1.list_peer_channels().channels[0].state ==  2)  # CHANNELD_NORMAL
 
     # Generate an invoice without amount:
     inv = l1.rpc.call('invoice', payload={
@@ -201,7 +205,10 @@ def test_node_listpays_preimage(clients, node_factory, bitcoind):
         amount=clnpb.AmountOrAll(amount=clnpb.Amount(msat=10**9))
     )
     bitcoind.generate_block(6, wait_for_mempool=1)
-    wait_for(lambda: gl1.list_peers().peers[0].channels[0].state == 2)  # CHANNELD_NORMAL
+
+    # the channels array is optional
+    wait_for(lambda: len(gl1.list_peer_channels().channels) > 0)
+    wait_for(lambda: gl1.list_peer_channels().channels[0].state ==  2)  # CHANNELD_NORMAL
 
     preimage = "00"*32
 


### PR DESCRIPTION
The goal of this PR is to provide a system that makes it easy and secure to construct runes with certain restrictions. We provide rule sets for common restrictions and combinations of those.

Example from a user perspective:
**A user wants to create and hand out a rune to a bookkeeping application (we all have to do taxes eventually):**
The application should not be allowed to move funds, neither off-chain nor on-chain but shall be able to read information from the node. A coarse rule set that is easy to understand (or at least human readable) and fulfills the task would be a **readonly** set that can be used to construct a rune that restricts the owner to read methods.

Example from an application perspective (pairing-protocol)
**A Podcast application uses greenlight without a distinct singer. The application wants to be authorized for a direct debit of max 1000 sat per week**
During the pairing-process the application would request a rune that is restricted to pay max _amt_ sat per _delta_time_ via the rule **rate(amt, delta_time)** that the user can then confirm or reject.

Tasks:
- [x] Add rune factory
- [x] Add exemplary set of rules
  - [x] readonly
  - [x] pay
  - [x] disjunct set
- [x] Check runes on signer
- [ ] Bindings for the rules and the factory

Rules (incomplete, loose ideas):
- [ ] only off-chain
- [ ] only on-chain
- [ ] rate limiting (amt, time, amt/time)
- [ ] one-time-rune (n-times)
- [ ] time-restricted (until date)

We do not have to implement every rule from the beginning but I am starting with a hand full of rule sets and recipes to ensure that our approach is modular enough.