### PR TITLE
signer: Print signer state when processing requests

### DIFF
--- a/libs/gl-client/src/persist.rs
+++ b/libs/gl-client/src/persist.rs
@@ -222,7 +222,7 @@ impl State {
                     if v.0 == *newver {
                         continue;
                     } else if v.0 > *newver {
-                        warn!("Ignoring outdated state version newver={}, we have oldver={}: newval={:?} vs oldval={:?}", newver, v.0, newval, v.1);
+                        warn!("Ignoring outdated state version newver={}, we have oldver={}: newval={:?} vs oldval={:?}", newver, v.0, serde_json::to_string(newval), serde_json::to_string(&v.1));
                         continue;
                     } else {
                         trace!(
@@ -513,18 +513,7 @@ impl Persist for MemoryPersister {
                 state_e.velocity_control.into(),
                 state_e.fee_velocity_control.into(),
             );
-/*
-            let state = CoreNodeState {
-                invoices: Default::default(),
-                issued_invoices: Default::default(),
-                payments: Default::default(),
-                excess_amount: 0,
-                log_prefix: "".to_string(),
-                velocity_control: node_state.velocity_control.into(),
-                fee_velocity_control: node_state.fee_velocity_control.into(),
-                last_summary: None,
-            };
-*/
+
             let entry = lightning_signer::persist::model::NodeEntry {
                 key_derivation_style: node.key_derivation_style,
                 network: node.network,

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -317,11 +317,6 @@ impl Signer {
         let prestate = {
             debug!("Updating local signer state with state from node");
             let mut state = self.state.lock().unwrap();
-            trace!(
-                "Applying diff between local and remote state: {:?}",
-                state.diff(&diff)
-            );
-
             state.merge(&diff).unwrap();
             trace!("Processing request {}", hex::encode(&req.raw));
             state.clone()
@@ -344,7 +339,8 @@ impl Signer {
         }
 
         let msg = vls_protocol::msgs::from_vec(req.raw).map_err(|e| Error::Signer(e))?;
-        log::trace!("Handling message {:?}", msg);
+        log::debug!("Handling message {:?}", msg);
+        log::trace!("Signer state {}", serde_json::to_string(&prestate).unwrap());
 
         let approver = Arc::new(MemoApprover::new(PositiveApprover()));
         approver.approve(approvals);
@@ -370,10 +366,6 @@ impl Signer {
         let signer_state: Vec<crate::pb::SignerStateEntry> = {
             debug!("Serializing state changes to report to node");
             let state = self.state.lock().unwrap();
-            trace!(
-                "Diff to state pre-request: {:?}",
-                prestate.diff(&state).unwrap()
-            );
             state.clone().into()
         };
 


### PR DESCRIPTION
This is to catch whatever is causing https://gitlab.com/lightning-signer/validating-lightning-signer/-/issues/397. We should be able to write a small testbench with `(signer_state, request)` tuples to reproduce the panic in an isolated environment.