### PR TITLE
Remove javascript tests on CI

### DIFF
--- a/.github/workflows/check-self.yml
+++ b/.github/workflows/check-self.yml
@@ -30,7 +30,3 @@ jobs:
     - name: Run python image
       run : |
         make docker-check-py
-
-    - name: Run javascript tests
-      run : |
-        make docker-check-js

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ include libs/gl-client-py/Makefile
 include libs/gl-client-js/Makefile
 include libs/gl-testing/Makefile
 
-check: check-rs check-py check-js
+check: check-rs check-py
 
 clean: clean-rs
 	rm -rf ${ARTIFACTS}
@@ -58,7 +58,7 @@ build-self: ensure-docker
 	(cd libs; cargo build --all)
 	(cd libs/gl-client-py && python3 -m maturin develop)
 
-check-all: check-self check-self-gl-client check-py check-js
+check-all: check-self check-self-gl-client check-py
 
 check-self: ensure-docker
 	PYTHONPATH=/repo/libs/gl-testing \
@@ -125,13 +125,6 @@ docker-check-py:
 		-t \
 		--rm \
 		-v ${REPO_ROOT}:/repo \
-		gltesting make build-self check-py
-
-docker-check-js:
-	docker run \
-		-t \
-		--rm \
-		-v ${REPO_ROOT}:/repoo \
 		gltesting make build-self check-py
 
 cln-versions/%/usr/local/bin/lightningd: cln-versions/lightningd-%.tar.bz2


### PR DESCRIPTION
We were actually running python-tests instead of javascript tests.

I decided to remove the code related to run this tests to make the current behavior more explicit.

I've created https://github.com/Blockstream/greenlight/issues/272 to ensure we do not forget about this