### PR TITLE
plugin: Default to 144 blocks of final CLTV delta

### DIFF
--- a/libs/gl-plugin/src/node/wrapper.rs
+++ b/libs/gl-plugin/src/node/wrapper.rs
@@ -75,6 +75,11 @@ impl Node for WrappedNodeServer {
                 .collect()
         });
 
+        pbreq.cltv = match pbreq.cltv {
+            Some(c) => Some(c), // Keep any set value
+            None => Some(144),  // Use a day if not set
+        };
+
         let res: Result<crate::responses::Invoice, crate::rpc::Error> =
             rpc.call("invoice", pbreq).await;
 


### PR DESCRIPTION
This can help us avoid killing channels when the signer inadvertently goes down, by increasing the time it has to return to 1 day. We still respect the explicitly set CLTV.

Reported-by: Roei Erez <@roeierez>