### PR TITLE
plugin: Do not reconnect on each `pay`

### DIFF
--- a/libs/gl-plugin/src/node/wrapper.rs
+++ b/libs/gl-plugin/src/node/wrapper.rs
@@ -298,7 +298,6 @@ impl Node for WrappedNodeServer {
     }
 
     async fn pay(&self, r: Request<pb::PayRequest>) -> Result<Response<pb::PayResponse>, Status> {
-        let _ = self.node_server.reconnect_peers().await;
         self.inner.pay(r).await
     }
 


### PR DESCRIPTION
Reconnecting can be racy, and may prolong the time until we have a
usable connection.

The problem is that reconnects force a reconnection on already
connected nodes too, which can then be racy with the `pay` itself
since `connected` will be `true` much earlier than the channel becomes
ready.
