### PR TITLE
signer: Extract invoices from `sendpay` command and add them to the known invoices

### DIFF
--- a/libs/gl-client/src/signer/auth.rs
+++ b/libs/gl-client/src/signer/auth.rs
@@ -8,7 +8,7 @@ use crate::Error;
 pub trait Authorizer {
     fn authorize(
         &self,
-        requests: Vec<Request>,
+        requests: &Vec<Request>,
     ) -> Result<Vec<Approval>, Error>;
 }
 
@@ -17,7 +17,7 @@ pub struct DummyAuthorizer {}
 impl Authorizer for DummyAuthorizer {
     fn authorize(
         &self,
-        _requests: Vec<Request>,
+        _requests: &Vec<Request>,
     ) -> Result<Vec<Approval>, Error> {
         Ok(vec![])
     }
@@ -28,7 +28,7 @@ pub struct GreenlightAuthorizer {}
 impl Authorizer for GreenlightAuthorizer {
     fn authorize(
         &self,
-        requests: Vec<Request>,
+        requests: &Vec<Request>,
     ) -> Result<Vec<Approval>, Error> {
         let approvals : Vec<_> = requests.iter().flat_map(|request| {
             match request {

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -398,7 +398,7 @@ impl Signer {
 
         use auth::Authorizer;
         let auth = auth::GreenlightAuthorizer {};
-        let approvals = auth.authorize(ctxrequests).map_err(|e| Error::Auth(e))?;
+        let approvals = auth.authorize(&ctxrequests).map_err(|e| Error::Auth(e))?;
         debug!("Current approvals: {:?}", approvals);
 
         let approver = Arc::new(MemoApprover::new(approver::ReportingApprover::new(

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -725,6 +725,23 @@ fn update_state_from_request(
     request: &model::Request,
     node: &lightning_signer::node::Node,
 ) -> Result<(), Error> {
+    use lightning_signer::invoice::Invoice;
+    use std::str::FromStr;
+    match request {
+        model::Request::SendPay(model::cln::SendpayRequest {
+            bolt11: Some(inv), ..
+        }) => {
+            let invoice = Invoice::from_str(inv).unwrap();
+            log::debug!(
+                "Adding invoice {:?} as side-effect of this sendpay {:?}",
+                invoice,
+                request
+            );
+            node.add_invoice(invoice).unwrap();
+        }
+        _ => {}
+    }
+
     Ok(())
 }
 

--- a/libs/gl-testing/Dockerfile
+++ b/libs/gl-testing/Dockerfile
@@ -82,9 +82,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV CARGO_TARGET_DIR=/tmp/target/
 ENV RUST_VERSION=1.70.0
 
-RUN groupadd -g $GID -o $DOCKER_USER &&\
-    useradd -m -u $UID -g $GID -o -s /bin/bash $DOCKER_USER
-
 # Set up a default logging filter. This includes all trace-level messages from greenlight components and validating lightning signer
 ENV RUST_LOG=gl_client=trace,tracing=warn,gl_signerproxy=trace,gl_plugin=trace,lightning_signer=trace,vls_protocol_signer=trace,vls_core=trace,vls_persist=trace,vls_protocol=trace,info
 
@@ -109,11 +106,16 @@ RUN apt-get update && apt-get install -qqy \
     python3-venv \
     nodejs \
     npm \
+    sudo \
     socat \
     unzip \
     wget \
     jq \
     && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g $GID -o $DOCKER_USER &&\
+    useradd -m -u $UID -g $GID -G sudo -o -s /bin/bash $DOCKER_USER && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Enumerate all CLN version we want `gl-testing` to find.
 ENV CLN_PATH=/opt/cln/v0.10.1/usr/local/bin/:/opt/cln/v0.10.2/usr/local/bin/:/opt/cln/v0.11.0.1/usr/local/bin/:/opt/cln/v0.11.2gl2/usr/local/bin/:/opt/cln/v22.11gl1/usr/local/bin/:/opt/cln/v23.05gl1/usr/local/bin/:/opt/cln/v23.08gl1/usr/local/bin/


### PR DESCRIPTION
This is necessary for `sendpay` to work correctly, i.e., have the signer accept a change in balance that results from a `sendpay`, and not complain about the unexplained balance change.

Notice that this adds invoices with whicht the `sendpay` is annotated with, but does not yet register a spontaneous payment if no invoice is attached.

Reported-by: @roeierez 