### PR TITLE
Add rustfmt warning to CI

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,28 @@
+name: Check Formatting
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+  workflow_dispatch:
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install Rust Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.73
+        components: rustfmt
+    
+    - name: Check Rust Formatting
+      continue-on-error: true
+      run: |
+        make check-rustfmt

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: check-rustfmt
+
 ifdef GL_DOCKER
 REPO_ROOT=/repo
 else
@@ -22,6 +24,8 @@ endif
 
 ARTIFACTS = \
 	.coverage
+
+CHANGED_RUST_SOURCES=$(shell git diff --name-only origin/main | grep '\.rs')
 
 # Variable to collect all generated files into, so we can clean and
 # rebuild them easily.
@@ -65,6 +69,12 @@ check-self: ensure-docker
 	pytest -vvv \
 	  /repo/libs/gl-testing \
 	  ${PYTEST_OPTS}
+
+check-rustfmt:
+	@if [ -n "${CHANGED_RUST_SOURCES}" ]; then \
+		rustfmt --edition 2021 --check ${CHANGED_RUST_SOURCES}; else \
+		echo "skip rustfmt check no changes detected ${CHANGED_RUST_SOURCES}"; \
+	fi
 
 ensure-docker:
 	@if [ "x${GL_DOCKER}" != "x1" ]; then \


### PR DESCRIPTION
This adds a job to the CI that checks every rust file that is changed by the PR for formatting. It will however not fail the CI (`continue-on-error: true`) and still result in a green check mark.

We could add `check-rustfmt` as a prerequisite to `check-self` if we want to run it locally and fail the CI if the formatter complains on changed files

Another option would be to use something like https://github.com/marketplace/actions/continue-on-error-comment to write a comment into the PR about formatting issues. That would not be as aggressive as to fail the CI or to enforce local checks.

Tell me what you think about this!