### PR TITLE
git: Mark generated pb2 files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Protobuf files should not be merged and show in diffs
+*_pb2.py       linguist-generated=true -diff -merge
+*_pb2.pyi      linguist-generated=true -diff -merge
+*_pb2_grpc.pyi linguist-generated=true -diff -merge
+*_pb2_grpc.py  linguist-generated=true -diff -merge
+


### PR DESCRIPTION
This should make diffs much simpler, and merging will treat these as atomic changes