### PR TITLE
plugin: Send a heartbeat as first message

### DIFF
--- a/libs/gl-client/src/signer/resolve.rs
+++ b/libs/gl-client/src/signer/resolve.rs
@@ -20,6 +20,7 @@ impl Resolver {
         // we do an early pass:
         let accept = match req {
             // Commands that simply have no context to check against
+	    Message::GetHeartbeat(_) => true,
             Message::Ecdh(_) => true,
             Message::Ping(_) => true,
             Message::Pong(_) => true,

--- a/libs/gl-signerproxy/src/hsmproxy.rs
+++ b/libs/gl-signerproxy/src/hsmproxy.rs
@@ -148,7 +148,10 @@ async fn grpc_connect() -> Result<GrpcClient, Error> {
 
 pub async fn run() -> Result<(), Error> {
     let args: Vec<String> = std::env::args().collect();
-    let request_counter = Arc::new(atomic::AtomicUsize::new(0));
+
+    // Start the counter at 1000 so we can inject some message before
+    // real requests if we want to.
+    let request_counter = Arc::new(atomic::AtomicUsize::new(1000));
     if args.len() == 2 && args[1] == "--version" {
         println!("{}", version());
         return Ok(());


### PR DESCRIPTION
The heartbeat serves two purposes: 1) start sending the entire state to the signer, so it can cache it locally, and 2) trigger a pruning round on the signer state.