### PR TITLE
rs: allow `FetchInvoice` requests to the signer

### DIFF
--- a/libs/gl-client/src/signer/model/cln.rs
+++ b/libs/gl-client/src/signer/model/cln.rs
@@ -56,6 +56,7 @@ pub fn decode_request(uri: &str, p: &[u8]) -> anyhow::Result<Request> {
 	"/cln.Node/Ping" => Request::Ping(PingRequest::decode(p)?),
 	"/cln.Node/SetChannel" => Request::SetChannel(SetchannelRequest::decode(p)?),
 	"/cln.Node/SignMessage" => Request::SignMessage(SignmessageRequest::decode(p)?),
+	"/cln.Node/FetchInvoice" => Request::FetchInvoice(FetchinvoiceRequest::decode(p)?),
 	"/cln.Node/Stop" => Request::Stop(StopRequest::decode(p)?),
 	"/cln.Node/ListClosedChannels" => Request::ListClosedChannels(ListclosedchannelsRequest::decode(p)?),
 	"/cln.Node/StaticBackup" => Request::StaticBackup(StaticbackupRequest::decode(p)?),

--- a/libs/gl-client/src/signer/model/mod.rs
+++ b/libs/gl-client/src/signer/model/mod.rs
@@ -70,6 +70,7 @@ pub enum Request {
     Ping(cln::PingRequest),
     SetChannel(cln::SetchannelRequest),
     SignMessage(cln::SignmessageRequest),
+    FetchInvoice(cln::FetchinvoiceRequest),
     Stop(cln::StopRequest),
     ListClosedChannels(cln::ListclosedchannelsRequest),
     StaticBackup(cln::StaticbackupRequest),


### PR DESCRIPTION
When calling the `FetchInvoice` command, incoming requests passing through the signer currently seem to fail with the error `Unknown URI {}, can't decode payload`, due to not being exposed in the signer. This small PR aims to fix this