### PR TITLE
Fix getinfo command in pyhton

### DIFF
--- a/tools/glcli/glcli/cli.py
+++ b/tools/glcli/glcli/cli.py
@@ -220,6 +220,8 @@ def dict2jsondict(d):
         return [dict2jsondict(e) for e in d]
     elif isinstance(d, dict):
         return {k: dict2jsondict(v) for k, v in d.items()}
+    elif isinstance(d, (bytes, bytearray)):
+        return d.hex()
     else:
         return d
 


### PR DESCRIPTION
Hello commiters. 

Currently I develop an apps about lightning network. 
I faced a problem like this.

```shell
$ glcli getinfo
[2023-12-14 14:13:01,134 - INFO] Configuring client with user identity.
Traceback (most recent call last):
  File "/usr/local/var/pyenv/versions/3.11.3/bin/glcli", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/glcli/cli.py", line 354, in getinfo
    pbprint(res)
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/site-packages/glcli/cli.py", line 236, in pbprint
    print(json.dumps(dta))
          ^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/var/pyenv/versions/3.11.3/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```

After investigating the cause, I felt `dict2jsondict` was wrong.
input data contains binary string (` 'channel': b''`) , but dict2jsondict dosn't convert it.
```python
{
  'id': '0372....8707',
  'alias': 'UNITEDSCAN-v23.08gl1',
  'color': '0372c3',
  'version': 'v23.08gl1',
  'lightning_dir': '/tmp/testnet',
  'our_features': {
    'init': '08a0800a8269a2',
    'node': '88...a2',
    'invoice': '02..000',
    'channel': b''},
  'blockheight': 2542787,
  'network': 'testnet',
  'fees_collected_msat': {'msat': 0}
}
```

So I tried to fix it, but what do you think?

Regards


