### PR TITLE
signer: Add preapproveinvoice for client-driven payments

### DIFF
--- a/libs/gl-client/src/signer/model/cln.rs
+++ b/libs/gl-client/src/signer/model/cln.rs
@@ -60,6 +60,7 @@ pub fn decode_request(uri: &str, p: &[u8]) -> anyhow::Result<Request> {
 	"/cln.Node/Stop" => Request::Stop(StopRequest::decode(p)?),
 	"/cln.Node/ListClosedChannels" => Request::ListClosedChannels(ListclosedchannelsRequest::decode(p)?),
 	"/cln.Node/StaticBackup" => Request::StaticBackup(StaticbackupRequest::decode(p)?),
+	"/cln.Node/PreApproveInvoice" => Request::PreApproveInvoice(PreapproveinvoiceRequest::decode(p)?),
         uri => return Err(anyhow!("Unknown URI {}, can't decode payload", uri)),
     })
 }

--- a/libs/gl-client/src/signer/model/mod.rs
+++ b/libs/gl-client/src/signer/model/mod.rs
@@ -47,6 +47,7 @@ pub enum Request {
     ListSendPays(cln::ListsendpaysRequest),
     ListTransactions(cln::ListtransactionsRequest),
     Pay(cln::PayRequest),
+    PreApproveInvoice(cln::PreapproveinvoiceRequest),
     ListNodes(cln::ListnodesRequest),
     WaitAnyInvoice(cln::WaitanyinvoiceRequest),
     WaitInvoice(cln::WaitinvoiceRequest),

--- a/libs/gl-client/src/signer/resolve.rs
+++ b/libs/gl-client/src/signer/resolve.rs
@@ -20,7 +20,7 @@ impl Resolver {
         // we do an early pass:
         let accept = match req {
             // Commands that simply have no context to check against
-	    Message::GetHeartbeat(_) => true,
+            Message::GetHeartbeat(_) => true,
             Message::Ecdh(_) => true,
             Message::Ping(_) => true,
             Message::Pong(_) => true,
@@ -89,6 +89,12 @@ impl Resolver {
                 }
                 (Message::PreapproveInvoice(l), Request::Pay(r)) => {
                     l.invstring.0 == r.bolt11.as_bytes()
+                }
+                (Message::PreapproveInvoice(l), Request::PreApproveInvoice(r)) => {
+                    // Manually calling preapproveinvoice should
+                    // always be allowed. The bolt11 string have to
+                    // match.
+                    l.invstring.0 == r.bolt11().as_bytes()
                 }
                 (_, _) => false,
             };


### PR DESCRIPTION
Manually sending `preapproveinvoice` was failing to adjust
the context on the signer, which then declined any subsequent HTLC
matching the invoice.

Reported-By: Domenico Gabriele