### PR TITLE
Remove duplicate bitcoin dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,12 +249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "bech32"
-version = "0.10.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
-
-[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,7 +260,7 @@ version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
- "bech32 0.9.1",
+ "bech32",
  "bitcoin_hashes 0.11.0",
  "bitcoinconsensus",
  "secp256k1 0.24.3",
@@ -279,26 +273,12 @@ version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
- "bech32 0.9.1",
+ "bech32",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
  "hex_lit",
  "secp256k1 0.27.0",
  "serde",
-]
-
-[[package]]
-name = "bitcoin"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5973a027b341b462105675962214dfe3c938ad9afd395d84b28602608bdcec7b"
-dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
- "hex-conservative",
- "hex_lit",
- "secp256k1 0.28.0",
 ]
 
 [[package]]
@@ -311,12 +291,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-private"
@@ -351,16 +325,6 @@ checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
  "serde",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals",
- "hex-conservative",
 ]
 
 [[package]]
@@ -1031,8 +995,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.5",
- "bech32 0.9.1",
- "bitcoin 0.31.0",
+ "bech32",
  "bytes 1.5.0",
  "chacha20poly1305",
  "cln-grpc",
@@ -1252,12 +1215,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "hex_lit"
@@ -1626,7 +1583,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788c0158526ec27a502043c2911ea6ea58fdc656bdf8749484942c07b790d23"
 dependencies = [
- "bech32 0.9.1",
+ "bech32",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
  "lightning 0.0.116",
@@ -1640,7 +1597,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb24878b0f4ef75f020976c886d9ad1503867802329cc963e0ab4623ea3b25c"
 dependencies = [
- "bech32 0.9.1",
+ "bech32",
  "bitcoin 0.29.2",
  "bitcoin_hashes 0.11.0",
  "lightning 0.0.118",
@@ -2776,16 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
-dependencies = [
- "bitcoin_hashes 0.13.0",
- "secp256k1-sys 0.9.0",
-]
-
-[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,15 +2746,6 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e67c467c38fd24bd5499dc9a18183b31575c12ee549197e3e20d57aa4fe3b7"
 dependencies = [
  "cc",
 ]

--- a/libs/gl-client/Cargo.toml
+++ b/libs/gl-client/Cargo.toml
@@ -37,7 +37,6 @@ tower = { version = "0.4" }
 rcgen = { version = "0.10.0", features = ["pem", "x509-parser"]}
 tempfile = "3.3.0"
 url = "2.4.0"
-bitcoin = "^0"
 serde = { version = "1", features = [ "derive" ] }
 vls-core = { workspace = true }
 vls-persist = { workspace = true }


### PR DESCRIPTION
This PR replaces the explicit `bitcoin` dependency with the `lightning_signer::bitcoin` re-exported one, for two reasons:

First, the explicit one it's not used. The re-exported `lightning_signer::bitcoin` is already used as such, for example

https://github.com/Blockstream/greenlight/blob/62ade9c53b68b8f7625725033121babb51720dbb/libs/gl-client/src/export.rs#L5-L8

Second, the explicit dependency brings with it a separate version into the dependency tree. Removing it and instead re-using the exported one consolidates the dependency tree and helps remove duplicates.

For example, before this PR, GL had 3 separate `bitcoin` versions in the dependency tree.

```bash
cargo tree --duplicate | grep bitcoin

...
bitcoin v0.29.2 (*)
bitcoin v0.30.2 (*)
bitcoin v0.31.0 (*)
```

With this PR, there are only 2 left:

```bash
cargo tree --duplicate | grep bitcoin

...
bitcoin v0.29.2 (*)
bitcoin v0.30.2 (*)
```

Related to https://github.com/Blockstream/greenlight/issues/335