### PR TITLE
Re-export the lightning crate

### DIFF
--- a/libs/gl-client/src/lib.rs
+++ b/libs/gl-client/src/lib.rs
@@ -69,6 +69,7 @@ pub enum Error {
 }
 
 pub use lightning_signer::bitcoin;
+pub use lightning_signer::lightning;
 pub use lightning_signer::lightning_invoice;
 
 pub(crate) const TCP_KEEPALIVE: Duration = Duration::from_secs(30);

--- a/libs/gl-client/src/signer/approver.rs
+++ b/libs/gl-client/src/signer/approver.rs
@@ -24,7 +24,7 @@ impl<A: Approve> Approve for ReportingApprover<A> {
     }
     fn approve_keysend(
         &self,
-        hash: lightning_signer::lightning::ln::PaymentHash,
+        hash: crate::lightning::ln::PaymentHash,
         amount_msat: u64,
     ) -> bool {
         log::warn!("unapproved keysend {:?} {:?}", hash, amount_msat);


### PR DESCRIPTION
This PR re-uses and re-exports the `lightning_signer::lightning` dependency.

This helps users of `gl-client` directly use it and avoid confusion around versioning.