### PR TITLE
CI: Set stable toolchain

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -65,7 +65,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         working-directory: libs/gl-client-py
-        rust-toolchain: nightly
+        rust-toolchain: stable
         target: ${{ matrix.target }}
         manylinux: auto
         args: --release --out dist


### PR DESCRIPTION
Python i686 failed on `nightly` (missing libatomic.so)
We may use `nightly` again once this is resolved.
