### PR TITLE
gci: Fix typo in the docs workflow file

### DIFF
--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    permission:
+    permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -13,7 +13,6 @@ jobs:
   build:
     permissions:
       pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Github repo
@@ -68,7 +67,7 @@ jobs:
         env:
           DOCSBRANCH: "gh-pages"
           DOCSREMOTE: "origin"
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GH_PAGES_PAT }}"
         run: |
           rm libs/gl-client-py/glclient/*.pyi
           PATH=$(pwd)/.venv/bin:$PATH make docs


### PR DESCRIPTION
`permission:` -> `permissions:`