### PR TITLE
Cln version manager

### DIFF
--- a/.github/workflows/cln-version-manager-py.yml
+++ b/.github/workflows/cln-version-manager-py.yml
@@ -1,0 +1,58 @@
+name: ClnVersionManager
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+    workflow_dispatch:
+    merge_roup:
+    push:
+      branches:
+        - master
+
+jobs:
+  source:
+    runs-on: ubuntu-20.04
+    steps:
+      # Check out the code
+      # We use a sparse check-out to ensure we only use the files we need
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: |
+            libs/cln-version-manager
+      - name: Move files to toplevel
+        run: mv ./libs/cln-version-manager/** .
+      # Install python-3.8
+      - name: Install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      # Load the poetry installation if it still cached
+      - name: Load cached Poetry installation
+        id: cached-poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.local  # the path depends on the OS
+          key: poetry-0  # increment to reset cache
+      # Install poetry. By default the poetry-files venv is created
+      # in ~/.cache/virtualenvs
+      - name: Install poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-interaction
+      - name: Run mypy
+        run: poetry run mypy
+      - name: Run tests
+        run: poetry run pytest tests
+
+    
+
+      
+    
+
+          
+        
+

--- a/.github/workflows/cln-version-manager-py.yml
+++ b/.github/workflows/cln-version-manager-py.yml
@@ -6,7 +6,7 @@ on:
       - synchronize
       - opened
     workflow_dispatch:
-    merge_roup:
+    merge_group:
     push:
       branches:
         - master

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -58,6 +58,7 @@ RUN poetry self add poetry-plugin-export
 ADD pyproject.toml /repo/pyproject.toml
 ADD libs/gl-client-py/pyproject.toml /repo/libs/gl-client-py/pyproject.toml
 ADD libs/gl-testing/pyproject.toml /repo/libs/gl-testing/pyproject.toml
+ADD libs/cln-version-manager/pyproject.toml /repo/libs/cln-version-manager/pyproject.toml
 
 WORKDIR repo
 
@@ -72,7 +73,7 @@ WORKDIR repo
 # don't have the code in the Docker-repo yet.
 RUN poetry lock
 RUN poetry export -f requirements.txt -o requirements.txt --with=dev
-RUN cat requirements.txt | sed '/gl\-testing/d' | sed '/gl\-client/d' > requirements2.txt
+RUN cat requirements.txt | sed '/@ file:\/\/\//d' > requirements2.txt
 RUN python -m pip install --upgrade pip && pip install wheel && pip install -r requirements2.txt
 
 # Later we will run this image under another user

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -267,7 +267,8 @@ ADD . /repo
 WORKDIR /repo
 
 # Add the remaining repositories to the python-path
-ENV PYTHONPATH=/repo/libs/gl-testing:/repo/libs/gl-client-py
+RUN poetry install
+RUN chmod -R a+rw /tmp/venv
 
 
 

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -259,6 +259,10 @@ RUN groupadd -g $GID -o $DOCKER_USER &&\
     useradd -m -u $UID -g $GID -G sudo -o -s /bin/bash $DOCKER_USER && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
+# Configure clnvm
+RUN mkdir -p /opt/clnvm; chmod a+rw /opt/clnvm
+ENV CLNVM_CACHE_DIR=/opt/clnvm
+
 # Create the required tmp-dicts
 RUN chmod a+rw /tmp
 RUN mkdir -p /tmp/gltesting/cargo && mkdir -p /tmp/gltesting/tmp

--- a/libs/cln-version-manager/.dockerignore
+++ b/libs/cln-version-manager/.dockerignore
@@ -1,0 +1,1 @@
+poetry.lock

--- a/libs/cln-version-manager/README.md
+++ b/libs/cln-version-manager/README.md
@@ -1,0 +1,23 @@
+# A version manager for Core Lightning binaries
+
+It is sometimes useful to download and install multiple versions of Core Lightning on a single machine.
+One use-case is to test your greenlight application. (This is also the only use-case this library supports at the moment).
+
+All versions of Core Lightning are installed in a configurable directory
+- `GLTESTING_CLN_PATH` if it is configured
+- `$XDG_CACHE_DIR/greenlight` if $XDG_CACHE_DIR is configured
+- `~/.cache/greenlight` otherwise
+
+## Usage
+
+To download all binaries 
+
+```
+clnvm get-all
+```
+
+To download a specific binarie
+
+```
+clnvm get --tag 23.01
+```

--- a/libs/cln-version-manager/README.md
+++ b/libs/cln-version-manager/README.md
@@ -16,7 +16,7 @@ To download all binaries
 clnvm get-all
 ```
 
-To download a specific binarie
+To download a specific binary
 
 ```
 clnvm get --tag 23.01

--- a/libs/cln-version-manager/clnvm/__init__.py
+++ b/libs/cln-version-manager/clnvm/__init__.py
@@ -4,4 +4,3 @@ from clnvm.cln_version_manager import ClnVersionManager
 __version__ = importlib.metadata.version("cln-version-manager")
 
 __all__ = ["ClnVersionManager"]
-

--- a/libs/cln-version-manager/clnvm/__init__.py
+++ b/libs/cln-version-manager/clnvm/__init__.py
@@ -1,0 +1,7 @@
+import importlib.metadata
+from clnvm.cln_version_manager import ClnVersionManager
+
+__version__ = importlib.metadata.version("cln-version-manager")
+
+__all__ = ["ClnVersionManager"]
+

--- a/libs/cln-version-manager/clnvm/__main__.py
+++ b/libs/cln-version-manager/clnvm/__main__.py
@@ -1,4 +1,4 @@
-
 if __name__ == "__main__":
     from clnvm.cli import run
+
     run()

--- a/libs/cln-version-manager/clnvm/__main__.py
+++ b/libs/cln-version-manager/clnvm/__main__.py
@@ -1,0 +1,4 @@
+
+if __name__ == "__main__":
+    from clnvm.cli import run
+    run()

--- a/libs/cln-version-manager/clnvm/cli.py
+++ b/libs/cln-version-manager/clnvm/cli.py
@@ -30,7 +30,7 @@ def get_all(force: bool) -> None:
     for version in versions:
         try:
             result = version_manager.get(version, force)
-            click.echo(result.path)
+            click.echo(result.lightningd)
         except Exception as e:
             click.echo(click.style(str(e), fg="red"), err=True)
 
@@ -43,7 +43,7 @@ def get(tag: str, force: bool) -> None:
         version_manager = ClnVersionManager()
         descriptor = version_manager.get_descriptor_from_tag(tag)
         node_version = version_manager.get(descriptor, force)
-        click.echo(node_version.path)
+        click.echo(node_version.lightningd)
     except Exception as e:
         # Print the error and return a non-zero status-code
         click.echo(click.style(str(e), fg="red"), err=True)
@@ -53,24 +53,20 @@ def get(tag: str, force: bool) -> None:
 @cli.command()
 @click.option("--tag", is_flag=True)
 @click.option("--lightningd", is_flag=True)
-@click.option("--path", is_flag=True)
+@click.option("--root-path", is_flag=True)
 @click.option("--bin-path", is_flag=True)
-def latest(tag: bool, lightningd: bool, path: bool, bin_path: bool) -> None:
+def latest(tag: bool, lightningd: bool, root_path: bool, bin_path: bool) -> None:
     version_manager = ClnVersionManager()
     latest = version_manager.latest()
 
     if tag:
         click.echo(latest.name)
     elif lightningd:
-        click.echo(latest.path)
+        click.echo(latest.lightningd)
     elif bin_path:
-        head, tail = os.path.split(latest.path)
-        click.echo(head)
-    elif path:
-        # Drop the /usr/local/bin/lightningd part
-        parts = latest.path.parts[:-4]
-        my_path = os.path.join(*parts)
-        click.echo(my_path)
+        click.echo(latest.bin_path)
+    elif root_path:
+        click.echo(latest.root_path)
     else:
         click.echo(latest.name)
 

--- a/libs/cln-version-manager/clnvm/cli.py
+++ b/libs/cln-version-manager/clnvm/cli.py
@@ -1,0 +1,91 @@
+import importlib
+import os
+import sys
+from typing import Optional
+
+import clnvm
+from clnvm.cln_version_manager import ClnVersionManager, VersionDescriptor
+
+# Handle the optional import and provide a nice error message if it fails
+_click = importlib.util.find_spec("click")
+if _click is None:
+    print("To use clnvm the `cli` feature must be installed")
+    print("You can install the feature using")
+    print("> pip install gltesting[cli]")
+    exit()
+
+import click
+
+
+@click.group()
+def cli() -> None:
+    pass
+
+
+@cli.command()
+@click.option("--force", is_flag=True)
+def get_all(force: bool) -> None:
+    version_manager = ClnVersionManager()
+    versions = version_manager.get_versions()
+    for version in versions:
+        try:
+            result = version_manager.get(version, force)
+            click.echo(result.path)
+        except Exception as e:
+            click.echo(click.style(str(e), fg="red"), err=True)
+
+
+@cli.command()
+@click.option("--tag", required=True)
+@click.option("--force", is_flag=True)
+def get(tag: str, force: bool) -> None:
+    try:
+        version_manager = ClnVersionManager()
+        descriptor = version_manager.get_descriptor_from_tag(tag)
+        node_version = version_manager.get(descriptor, force)
+        click.echo(node_version.path)
+    except Exception as e:
+        # Print the error and return a non-zero status-code
+        click.echo(click.style(str(e), fg="red"), err=True)
+        sys.exit(1)
+
+
+@cli.command()
+@click.option("--tag", is_flag=True)
+@click.option("--lightningd", is_flag=True)
+@click.option("--path", is_flag=True)
+@click.option("--bin-path", is_flag=True)
+def latest(tag: bool, lightningd: bool, path: bool, bin_path: bool) -> None:
+    version_manager = ClnVersionManager()
+    latest = version_manager.latest()
+
+    if tag:
+        click.echo(latest.name)
+    elif lightningd:
+        click.echo(latest.path)
+    elif bin_path:
+        head, tail = os.path.split(latest.path)
+        click.echo(head)
+    elif path:
+        # Drop the /usr/local/bin/lightningd part
+        parts = latest.path.parts[:-4]
+        my_path = os.path.join(*parts)
+        click.echo(my_path)
+    else:
+        click.echo(latest.name)
+
+
+@cli.command()
+def info() -> None:
+    version_manager = ClnVersionManager()
+    click.echo(f"cln Version Manager {clnvm.__version__}")
+    click.echo("")
+    click.echo(f"path = {version_manager._cln_path}")
+
+
+def run() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    run()

--- a/libs/cln-version-manager/clnvm/cln_version_manager.py
+++ b/libs/cln-version-manager/clnvm/cln_version_manager.py
@@ -72,6 +72,10 @@ CLN_VERSIONS = [
 ]
 
 
+_LIGHTNINGD_REL_PATH = Path("usr/local/bin/lightningd")
+_BIN_REL_PATH = Path("usr/local/bin")
+
+
 def _get_cln_version_path(cln_path: Optional[PathLike] = None) -> Path:
     """
     Retrieve the path where all cln-versions are stored
@@ -179,7 +183,9 @@ class ClnVersionManager:
 
         return NodeVersion(
             name=cln_version.tag,
-            path=target_path / "usr" / "local" / "bin" / "lightningd",
+            lightningd=target_path / _LIGHTNINGD_REL_PATH,
+            bin_path=target_path / _BIN_REL_PATH,
+            root_path=target_path,
         )
 
     def _download(self, cln_version: VersionDescriptor, target_path: Path) -> None:
@@ -210,7 +216,8 @@ class ClnVersionManager:
         ignore_hash = bool(os.environ.get("GL_TESTING_IGNORE_HASH", False))
         if ignore_hash:
             logger.warning(
-                "Checking the has of remote versions is disabled which is unsafe. Try to unset GL_TESTING_IGNORE_HASH"
+                "Checking the hash of remote versions is disabled which is unsafe. "
+                "Try to unset GL_TESTING_IGNORE_HASH"
             )
 
         if (not ignore_hash) and content_sha != cln_version.checksum:
@@ -244,7 +251,7 @@ class ClnVersionManager:
 
         try:
             # We verify if the path matches the version
-            lightningd_path = target_path / "usr" / "local" / "bin" / "lightningd"
+            lightningd_path = target_path / _LIGHTNINGD_REL_PATH
             version = (
                 subprocess.check_output([lightningd_path, "--version"])
                 .strip()

--- a/libs/cln-version-manager/clnvm/cln_version_manager.py
+++ b/libs/cln-version-manager/clnvm/cln_version_manager.py
@@ -1,0 +1,263 @@
+from dataclasses import dataclass
+from io import BytesIO, StringIO
+import hashlib
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+from typing import Dict, List, Optional, Tuple, Union
+import shutil
+from multiprocessing.pool import ThreadPool as Pool
+
+import requests
+from clnvm.utils import NodeVersion
+from clnvm.errors import UnrunnableVersion, HashMismatch, VersionMismatch
+
+PathLike = Union[os.PathLike, str]
+
+
+@dataclass
+class VersionDescriptor:
+    tag: str
+    url: str
+    checksum: str
+
+
+logger = logging.getLogger(__name__)
+
+# Stores all versions of cln that can be scheduled
+CLN_VERSIONS = [
+    VersionDescriptor(
+        tag="v0.10.1",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v0.10.1.tar.bz2",
+        checksum="928f09a46c707f68c8c5e1385f6a51e10f7b1e57c5cef52f5b73c7d661500af5",
+    ),
+    VersionDescriptor(
+        tag="v0.10.2",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v0.10.2.tar.bz2",
+        checksum="c323f2e41ffde962ac76b2aeaba3f2360b3aa6481028f11f12f114f408507bfe",
+    ),
+    VersionDescriptor(
+        tag="v0.11.0.1",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v0.11.0.1.tar.bz2",
+        checksum="0f1a49bb8696db44a9ab93d8a226e82b4d3de03c9bae2eb38b750d75d4bcaceb",
+    ),
+    VersionDescriptor(
+        tag="v0.11.2gl2",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v0.11.2gl2.tar.bz2",
+        checksum="b15866b7beea239aaf4e38931fe09ee85bf2e58ad61c2ec79b83bb361364bf97",
+    ),
+    VersionDescriptor(
+        tag="v0.11.2",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v0.11.2.tar.bz2",
+        checksum="95209242d8ddc4879b959fb5e4594b4d2dcf7bac7227ec7c421ab05019de8633",
+    ),
+    VersionDescriptor(
+        tag="v22.11gl1",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v22.11gl1.tar.bz2",
+        checksum="40b6c50babdc74d9fd251816efa46de0c12cac88d72e0c7b02457a8949d2690b",
+    ),
+    VersionDescriptor(
+        tag="v23.05gl1",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v23.05gl1.tar.bz2",
+        checksum="e1a57a8ced59fd92703fad8e34926c014b71ee0c13cc7f863cb18b2ca19a58b9",
+    ),
+    VersionDescriptor(
+        tag="v23.08gl1",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v23.08gl1.tar.bz2",
+        checksum="700e2f4765ba2f8d83ea26e0dc5b47c7176b665c7d6945bdfed2207c90ed9ebd",
+    ),
+]
+
+
+def _get_cln_version_path(cln_path: Optional[PathLike] = None) -> Path:
+    """
+    Retrieve the path where all cln-versions are stored
+    """
+    if cln_path is not None:
+        return Path(cln_path).resolve()
+
+    cln_cache_dir = os.environ.get("CLNVM_CACHE_DIR")
+    if cln_cache_dir is not None:
+        return Path(cln_cache_dir).resolve()
+
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home is not None:
+        return Path(xdg_cache_home).resolve() / "clnvm"
+
+    else:
+        return Path("~/.cache").expanduser().resolve() / "clnvm"
+
+
+class ClnVersionManager:
+    def __init__(
+        self,
+        cln_path: Optional[PathLike] = None,
+        cln_versions: Optional[List[VersionDescriptor]] = None,
+    ):
+        self._cln_path: Path = _get_cln_version_path(cln_path)
+        if cln_versions is not None:
+            self._cln_versions = cln_versions
+        else:
+            self._cln_versions = CLN_VERSIONS
+
+    def get_versions(self) -> List[VersionDescriptor]:
+        """
+        Retrieves the list of Core Lightning versions
+        """
+        return self._cln_versions
+
+    def is_available(self, cln_version: VersionDescriptor) -> bool:
+        target_path = self.get_target_path(cln_version)
+        return os.path.exists(target_path)
+
+    def get_all(self, force: bool = False) -> Dict[str, NodeVersion]:
+        """
+        Downloads all versions of Core Lightning
+
+        Args:
+            force (False): If force is True the data will be overriden
+        """
+        versions = list(self.get_versions())
+
+        def do_download(
+            version: VersionDescriptor,
+        ) -> Optional[Tuple[str, NodeVersion]]:
+            try:
+                return version.tag, self.get(version, force)
+            except Exception:
+                logger.exception(
+                    "Failed to download %s. This version will be ignored", version.tag
+                )
+                return None
+
+        def do() -> List[Tuple[str, NodeVersion]]:
+            with Pool(10) as p:
+                data = p.map(do_download, versions)
+
+            return [t for t in data if t is not None]
+
+        return dict(do())
+
+    def get_target_path(self, cln_version: VersionDescriptor) -> Path:
+        """Computes the path corresponding to which a cln version should be downloaded"""
+        return Path(self._cln_path) / cln_version.checksum / cln_version.tag
+
+    def get_descriptor_from_tag(self, tag: str) -> VersionDescriptor:
+        cln_dict = {d.tag: d for d in CLN_VERSIONS}
+        descriptor = cln_dict.get(tag, None)
+
+        if descriptor is None:
+            raise ValueError(f"Failed to find version {tag}")
+
+        return descriptor
+
+    def latest(self) -> NodeVersion:
+        vs = [d.tag for d in self.get_versions()]
+        latest = max(vs)
+        descriptor = self.get_descriptor_from_tag(latest)
+        return self.get(descriptor)
+
+    def get(self, cln_version: VersionDescriptor, force: bool = False) -> NodeVersion:
+        """
+        Ensures the provided version exists.
+        It returns the path to the corresponding binary
+        """
+        target_path = self.get_target_path(cln_version)
+
+        if not os.path.exists(target_path):
+            self._download(cln_version, target_path)
+        elif force:
+            shutil.rmtree(target_path)
+            self._download(cln_version, target_path)
+        else:
+            # Files are already downloaded
+            # We don't do anything
+            pass
+
+        return NodeVersion(
+            name=cln_version.tag,
+            path=target_path / "usr" / "local" / "bin" / "lightningd",
+        )
+
+    def _download(self, cln_version: VersionDescriptor, target_path: Path) -> None:
+        """Downloads the provided cln_version"""
+        tag = cln_version.tag
+        logger.info("Downloading version %s to %s", tag, target_path)
+
+        # Retrieve the version from the provided url
+        response = requests.get(cln_version.url)
+        if response.status_code != 200:
+            logger.warning(
+                "Failed to retrieve %s: %s - %s",
+                tag,
+                response.status_code,
+                response.content[:124],
+            )
+            raise Exception(f"Failed to find version {tag}")
+
+        data = response.content
+
+        # We check the hash of the downloaded data
+        # If the hash doesn't match we stop and alert the user
+        m = hashlib.sha256()
+        m.update(data)
+        content_sha = m.hexdigest()
+
+        logger.debug("Downloaded version %s with checksum %s", tag, content_sha)
+        ignore_hash = bool(os.environ.get("GL_TESTING_IGNORE_HASH", False))
+        if ignore_hash:
+            logger.warning(
+                "Checking the has of remote versions is disabled which is unsafe. Try to unset GL_TESTING_IGNORE_HASH"
+            )
+
+        if (not ignore_hash) and content_sha != cln_version.checksum:
+            raise HashMismatch(
+                tag=cln_version.tag, expected=cln_version.checksum, actual=content_sha
+            )
+
+        # We extract the downloaded tar-file in the section below.
+        # Note, that we never put the tar-file on disk. We extract
+        # it straight from memory
+        #
+        # In python 3.12 the `filter`-argument was introduced
+        # to `TarFile.extractall`.
+        #
+        # Using this argument provide us extra security against
+        # malicious .tar-files.
+        #
+        # The extra security is nice to have. We used the hash to
+        # check the authenticity of our .tar-files a few lines above.
+        #
+        # We'll use the filter argument if it is available.
+        # In the other case we rely on the hash to keep our users safe
+        content_fh = BytesIO(data)
+        tf = tarfile.open(fileobj=content_fh)
+
+        current_version = sys.version_info
+        if current_version.minor >= 12:
+            tf.extractall(path=target_path, filter="data")
+        else:
+            tf.extractall(path=target_path)
+
+        try:
+            # We verify if the path matches the version
+            lightningd_path = target_path / "usr" / "local" / "bin" / "lightningd"
+            version = (
+                subprocess.check_output([lightningd_path, "--version"])
+                .strip()
+                .decode("ASCII")
+            )
+        except Exception as e:
+            # Clean-up the bad version
+            shutil.rmtree(target_path)
+            raise UnrunnableVersion(tag=cln_version.tag) from e
+
+        if version != tag:
+            # Clean-up teh bad version
+            shutil.rmtree(target_path)
+            raise VersionMismatch(expected=tag, actual=version)
+
+        return

--- a/libs/cln-version-manager/clnvm/errors.py
+++ b/libs/cln-version-manager/clnvm/errors.py
@@ -1,0 +1,49 @@
+class UnrunnableVersion(Exception):
+
+    def __init__(self, tag: str):
+        self.tag = tag
+
+    def __str__(self) -> str:
+        return f"Failed to run Core Lightning {self.tag}"
+
+    def __repr__(self) -> str:
+        return f"UnrunnableVersion(tag={self.tag})"
+
+
+class UnknownVersion(Exception):
+
+    def __init__(self, tag: str):
+        self.tag = tag
+
+    def __str__(self) -> str:
+        return f"Unknown version {self.tag}"
+
+    def __repr__(self) -> str:
+        return f"UnknownVersoin(tag={self.tag})"
+
+
+class VersionMismatch(Exception):
+
+    def __init__(self, expected: str, actual: str):
+        self.expected = expected
+        self.actual = actual
+
+    def __str__(self) -> str:
+        return f"Unexpected version of `lightningd`. Downloaded {self.actual} but expected {self.expected}"
+
+    def __repr__(self) -> str:
+        return f"VersionMismatch(expected={self.expected}, actual={self.actual})"
+
+
+class HashMismatch(Exception):
+
+    def __init__(self, tag: str, expected: str, actual: str):
+        self.tag = tag
+        self.actual = actual
+        self.expected = expected
+
+    def __str__(self) -> str:
+        return f"The cryptographic hash of '{self.tag}' doesn't match."
+
+    def __repr__(self) -> str:
+        return f"HashMismatch(tag={self.tag}, actual={self.actual}, expected={self.expected})"

--- a/libs/cln-version-manager/clnvm/utils.py
+++ b/libs/cln-version-manager/clnvm/utils.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class NodeVersion:
+    """Path to the lightningd executable"""
+
+    path: Path
+    """Name of the version"""
+    name: str

--- a/libs/cln-version-manager/clnvm/utils.py
+++ b/libs/cln-version-manager/clnvm/utils.py
@@ -4,8 +4,17 @@ from pathlib import Path
 
 @dataclass
 class NodeVersion:
-    """Path to the lightningd executable"""
+    """Contains version information and executable to a node.
 
-    path: Path
+    It also includes the path used to find the executable
+    """
+
+    """Path to the lightningd executable"""
+    lightningd: Path
+    """Path to the bin-folder of the release"""
+    bin_path: Path
+    """Path to the root folder of the release.
+    Typically, this contains the `usr` directory"""
+    root_path: Path
     """Name of the version"""
     name: str

--- a/libs/cln-version-manager/mypy.ini
+++ b/libs/cln-version-manager/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+files=clnvm,tests
+
+warn_return_any = True
+warn_unused_configs = True
+disallow_untyped_defs = True

--- a/libs/cln-version-manager/pyproject.toml
+++ b/libs/cln-version-manager/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.poetry]
+name = "cln-version-manager"
+version = "0.1.0"
+description = "A version manager for Core Lightning Binaries"
+authors = ["Erik De Smedt <edesmedt@blockstream.com>"]
+license = "MIT"
+readme = "README.md"
+
+packages = [
+    { include = "clnvm" },
+]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+requests = "^2"
+click = "^8"
+
+[tool.poetry.group.dev.dependencies]
+types-requests = "^2.31"
+pytest = "^8"
+mypy = "^1.8.0"
+types-click = "^7"
+black = "^24.2.0"
+
+[tool.poetry.group.lsp_ide.dependencies]
+python-lsp-server = "^1.10.0"
+
+[tool.poetry.scripts]
+clnvm = "clnvm.cli:run"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/libs/cln-version-manager/tests/test_version_manager.py
+++ b/libs/cln-version-manager/tests/test_version_manager.py
@@ -1,0 +1,34 @@
+from unittest import mock
+import pytest
+import shutil
+import os
+
+import requests
+
+from clnvm.cln_version_manager import ClnVersionManager
+from clnvm.cln_version_manager import CLN_VERSIONS
+
+
+def get_tmp_dir(name: str) -> str:
+    tmp_dir = f"/tmp/gl-testing/case/{name}"
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)
+    os.makedirs(tmp_dir)
+    return tmp_dir
+
+
+def test_download_cln_version() -> None:
+    # Only download the first 2 versions in the test
+    versions = CLN_VERSIONS[-2:]
+    vm = ClnVersionManager(
+        cln_versions=versions, cln_path=get_tmp_dir("test_download_cln_version")
+    )
+    vm.get_all()
+
+    # get them again to verify we don't download them
+    with mock.patch("requests.get") as request_mock:
+        vm.get_all()
+        assert not request_mock.get.called
+
+    # get them again using force to ensure we do download them
+    vm.get_all(force=True)

--- a/libs/cln-version-manager/tests/test_version_manager.py
+++ b/libs/cln-version-manager/tests/test_version_manager.py
@@ -29,6 +29,3 @@ def test_download_cln_version() -> None:
     with mock.patch("requests.get") as request_mock:
         vm.get_all()
         assert not request_mock.get.called
-
-    # get them again using force to ensure we do download them
-    vm.get_all(force=True)

--- a/libs/gl-testing/gltesting/node.py
+++ b/libs/gl-testing/gltesting/node.py
@@ -48,12 +48,12 @@ class NodeProcess(TailableProc):
         TailableProc.__init__(self, str(directory), verbose=True)
         self.logger = logging.getLogger("gltesting.node.Node")
         self.identity = identity
-        self.version  = version
+        self.version = version
         self.proc: Optional[subprocess.Popen] = None
         self.directory = directory
         self.node_id = node_id
         self.init_msg = init_msg
-        self.executable = self.version.path
+        self.executable = self.version.lightningd
         self.bind: Optional[str] = None
         self.grpc_uri: Optional[str] = None
         self.network = network
@@ -120,14 +120,14 @@ class NodeProcess(TailableProc):
         path = os.environ.get('PATH')
         # Need to add the subdaemon directory to PATH so the
         # signerproxy can find the version.
-        libexec_path = self.executable.parent / '..' / 'libexec' / 'c-lightning'
+        libexec_path = self.executable.parent.parent / 'libexec' / 'c-lightning'
 
         self.grpc_port = reserve()
         self.bind = f"127.0.0.1:{self.grpc_port}"
         self.grpc_uri = f"https://localhost:{self.grpc_port}"
         self.env.update({
             "GL_CERT_PATH": self.directory / "certs",
-            "PATH": f"{self.version.path}:{libexec_path}:{path}",
+            "PATH": f"{self.version.lightningd}:{libexec_path}:{path}",
             "CLN_VERSION": self.version.name,
             "GL_NODE_NETWORK": self.network,
             "GL_NODE_ID": self.node_id.hex(),

--- a/libs/gl-testing/gltesting/scheduler.py
+++ b/libs/gl-testing/gltesting/scheduler.py
@@ -72,9 +72,18 @@ def enumerate_cln_versions():
 
     versions = {}
     for v in version_paths:
+        lightningd = Path(v).resolve()
+        path_parts = lightningd.parts
+        bin_path = Path(*path_parts[:-1])
+        root_path = Path(*path_parts[:-4])
+
         logging.debug(f"Detecting version of lightningd at {v}")
         vs = subprocess.check_output([v, "--version"]).strip().decode("ASCII")
-        versions[vs] = NodeVersion(path=Path(v).resolve(), name=vs)
+        versions[vs] = NodeVersion(
+            lightningd=lightningd,
+            bin_path=bin_path,
+            root_path=root_path,
+            name=vs)
         logging.debug(f"Determined version {vs} for executable {v}")
 
     logging.info(f"Found {len(versions)} versions: {versions}")

--- a/libs/gl-testing/gltesting/utils.py
+++ b/libs/gl-testing/gltesting/utils.py
@@ -1,14 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 
-@dataclass
-class NodeVersion:
-    # The path that we should use when calling `lightningd`, it is
-    # version specific
-    path: str
-    # The stringified version number
-    name: str
-
+from clnvm.utils import NodeVersion
 
 @dataclass
 class SignerVersion:

--- a/libs/gl-testing/pyproject.toml
+++ b/libs/gl-testing/pyproject.toml
@@ -37,6 +37,7 @@ pytest-sugar = "^0.9.7"
 # Contributors should use `poetry install` in the project root
 # to insure the installation is editable from local sources.
 gl-client = "^0.1.11"
+cln-version-manager = "^0.1.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"

--- a/libs/gl-testing/pyproject.toml
+++ b/libs/gl-testing/pyproject.toml
@@ -42,6 +42,8 @@ cln-version-manager = "^0.1.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "^1"
 typed-ast = "^1.5.4"
+cln-version-manager = { path="../cln-version-manager", develop=true }
+grpcio-tools = "^1.62.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ package-mode=false
 python = ">=3.8,<4.0"
 gl-client = {path = "./libs/gl-client-py", develop=true}
 gltesting = {path = "./libs/gl-testing", develop=true}
+cln-version-manager = {path = "./libs/cln-version-manager", develop=true}
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"
@@ -15,6 +16,9 @@ maturin = {version = ">=1.0,<1.3.2", extras = ["patchelf"]}
 mypy-protobuf = "^3.5"
 typed-ast = "^1.5.4"
 grpc-stubs= "^1.53.0"
+
+[tool.poetry.group.dev-cln-version-manager.dependencies]
+types-requests = "^2.31"
 
 [tool.poetry.group.docs]
 optional=true


### PR DESCRIPTION
I've introduced `cln_version_manager`.

It is currently very hard to run `gl-testing` in standalone-mode.
One of the dependencies of `gl-testing` are a wide range of Core Lightning versions.
These files are packaged into the docker-file.

I've adapted the `gl-testing` python-module to download the Core Lightning binaries for the user.
It will download them to `XDG_CACHE_DIR` by default but users can configure their folder.

