### PR TITLE
Add Credentials support for `glcli`

### DIFF
--- a/tools/glcli/glcli/cli.py
+++ b/tools/glcli/glcli/cli.py
@@ -331,6 +331,15 @@ def recover(ctx):
 
     pbprint(res)
 
+@scheduler.command()
+@click.pass_context
+def upgradecreds(ctx):
+    signer = Signer(Tls(Creds()))
+    creds = Credentials.as_device().upgrade(ctx.obj.scheduler.inner, signer.inner.inner).build()
+
+    with open("credentials.gfs", "wb") as f:
+        f.write(creds.to_bytes())
+
 
 @scheduler.command()
 @click.pass_context

--- a/tools/glcli/pyproject.toml
+++ b/tools/glcli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "greenlight-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["Christian Decker <decker@blockstream.com>"]
 license = "MIT"
@@ -14,7 +14,7 @@ python = "^3.8"
 click = "^8"
 grpcio = "^1"
 protobuf = "^4"
-gl-client = "^0.1"
+gl-client = { path = "../../libs/gl-client-py", develop = false}
 
 [tool.poetry.group.dev.dependencies]
 mypy-protobuf = "^3.5.0"


### PR DESCRIPTION
This PR reflects the changes that have been added through main-0.2 to the command line tool.

Credentials are written to disk and restored from disk when interacting with `glcli`. This PR also adds an `upgradecreds` command that can upgrade from pre main-0.2 to an actual credentials set.

Please verify that it works as intended:

old: `< main-0.2`
new: `>= main-0.2`

These require to run an old signer apart from from glcli
- old `signer` existing node with with old `glcli` -> should still work

These should work out of the box
- old `signer` registered node, with new `signer` and new `glcli` -> should not work and require `upgradecreds`, should work afterwards
- new `signer` registered node with new `glcli` -> should work
