### PR TITLE
Drop support for npn_protocols

### DIFF
--- a/libs/gl-testing/gltesting/identity.py
+++ b/libs/gl-testing/gltesting/identity.py
@@ -59,10 +59,6 @@ class Identity(object):
         s.load_cert_chain(self.cert_chain_path, keyfile=self.private_key_path)
         s.load_verify_locations(capath=self.caroot_path)
         s.set_alpn_protocols(['h2'])
-        try:
-            s.set_npn_protocols(['h2'])
-        except NotImplementedError:
-            pass
         return s
 
     def __str__(self):


### PR DESCRIPTION
`set_npn_protocols` has been removed in python 3.11. 

We are already using `set_alpn_protocols` so I think we can drop it safely.

This should help us to run `gl-testing` in standalone mode