### PR TITLE
client: Adjust the keepalive interval for the load balancer

### DIFF
--- a/libs/gl-client/src/lib.rs
+++ b/libs/gl-client/src/lib.rs
@@ -73,5 +73,5 @@ pub use lightning_signer::bitcoin;
 pub use lightning_signer::lightning;
 pub use lightning_signer::lightning_invoice;
 
-pub(crate) const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+pub(crate) const TCP_KEEPALIVE: Duration = Duration::from_secs(5);
 pub(crate) const TCP_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(90);


### PR DESCRIPTION
Turns out the load-balancer we are using has a very short keepalive timeout, and our old value of 30 seconds was long enough for it to drop the connection. Setting this to 5 seconds on the client, and keeping 30 seconds for the signer until we have the signer notifications working again.