### PR TITLE
Fix Cargo Clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ DOCKER_OPTIONS= \
 	--user $(shell id -u):$(shell id -g) \
 	-e TMPDIR=/tmp/gltesting/tmp \
 	-v /tmp/gltesting/tmp:/tmp/gltesting/tmp \
-	-e CARGO_TARGET_DIR=/tmp/gltesting/target \
+	-e CARGO_TARGET_DIR=/tmp/gltesting/target/target \
 	-v /tmp/gltesting/target:/tmp/gltesting/target \
 	-v /tmp/gltesting/cargo/registry:/opt/cargo/registry \
 	-v ${REPO_ROOT}:/repo


### PR DESCRIPTION
To reproduce the issue do `make docker-image`, `make docker-shell`,
`cargo clean`.

The issue is that you lack the rights to delete `tmp/gltesting/target`.
The folder was added as a volume and cannot be deleted.

We keep the rust target directory in `/tmp/gltesting/target/target`
instead so it can be safely deleted.

I'd recommend to run `rm -rf /tmp/gltesting` on the host-machine after merging this update.
