### PR TITLE
lightningd fails to resolve localhost

### DIFF
--- a/libs/gl-testing/gltesting/node.py
+++ b/libs/gl-testing/gltesting/node.py
@@ -82,7 +82,7 @@ class NodeProcess(TailableProc):
             '--log-level=debug',
             '--bitcoin-rpcuser=rpcuser',
             '--bitcoin-rpcpassword=rpcpass',
-            f'--bitcoin-rpcconnect=localhost:{self.bitcoind.rpcport}',
+            f'--bitcoin-rpcconnect=127.0.0.1:{self.bitcoind.rpcport}',
             "--disable-plugin=commando",
             '--rescan=1',
             "--log-timestamps=false",


### PR DESCRIPTION
The docker-image was failing to execute the tests on my machine.

A greenlight node connects to a `bitcoind`-proxy which should be exposed on `localhost`. For some reason, the proxy isn't always accepting connections when `localhost` is used.

This works
```
bitcoin-cli --rpcconnect=127.0.0.1:<proxy_port>
```

This doesn't work
```
bitcoin-cli --rpcoconnect=localhost:<proxy_port>
```

I'm not sure if this is the right approach.
We know our `bitcoind` proxy only supports `ipv4`. So I don't see a good reason to go for the more universal `localhost`?