### PR TITLE
use cln version manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,6 @@ CHANGED_RUST_SOURCES=$(shell git diff --name-only origin/main | grep '\.rs')
 # rebuild them easily.
 GENALL =
 
-CLN_VERSIONS = \
-	v0.10.1 \
-	v0.10.2 \
-	v0.11.0.1 \
-	v0.11.2gl2 \
-	v0.11.2 \
-	v22.11gl1 \
-	v23.05gl1 \
-	v23.08gl1
-
 DOCKER_OPTIONS= \
 	--rm \
 	--user $(shell id -u):$(shell id -g) \
@@ -50,8 +40,6 @@ DOCKER_OPTIONS= \
 	-v /tmp/gltesting/target:/tmp/gltesting/target \
 	-v /tmp/gltesting/cargo/registry:/opt/cargo/registry \
 	-v ${REPO_ROOT}:/repo
-
-CLN_TARGETS = $(foreach VERSION,$(CLN_VERSIONS),cln-versions/$(VERSION)/usr/local/bin/lightningd)
 
 .PHONY: ensure-docker build-self check-self docker-image docs wheels
 
@@ -137,16 +125,6 @@ docker-check-py: docker-volumes
 		-t \
 		${DOCKER_OPTIONS} \
 		gltesting make build-self check-py
-
-cln-versions/%/usr/local/bin/lightningd: cln-versions/lightningd-%.tar.bz2
-	@echo "Extracting $* from tarball $< into cln-versions/$*/"
-	mkdir -p "cln-versions/$*"
-	tar -xjf $< -C "cln-versions/$*/"
-
-cln-versions/lightningd-%.tar.bz2:
-	mkdir -p cln-versions
-	wget -q "https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-$*.tar.bz2" -O $@
-
 
 cln: ${CLN_TARGETS}
 

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -110,20 +110,15 @@ RUN chmod a+rwx -R $CARGO_HOME
 # -----------------------------------------
 # gl-testing requires multiple versions of Core Lightning
 # Download all versions so they can be copied to our dev-container
-FROM ubuntu:20.04 as cln-downloader
-RUN apt update && apt install wget make git -qqy
+FROM python-builder as cln-downloader
 
-# Add all the makefiles
-# Althoug we only need the main one here we have to include all of them
-ADD Makefile /repo/Makefile
-ADD libs/gl-testing/Makefile /repo/libs/gl-testing/Makefile
-ADD libs/gl-client-py/Makefile /repo/libs/gl-client-py/Makefile
-ADD libs/gl-client/Makefile /repo/libs/gl-client/Makefile
+RUN mkdir -p /opt/cln/
+ENV CLNVM_CACHE_DIR=/opt/cln
 
-WORKDIR /repo
+ADD libs/cln-version-manager /repo/libs/cln-version-manager
+RUN cd /repo/libs/cln-version-manager; python -m pip install .
 
-RUN git init && make cln
-RUN chmod a+x -R /repo/cln-versions/
+# RUN /tmp/venv/bin/python -m clnvm get -all
 
 # -------------------------------------
 # STAGE: bitcoin-downloader

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -116,9 +116,9 @@ RUN mkdir -p /opt/cln/
 ENV CLNVM_CACHE_DIR=/opt/cln
 
 ADD libs/cln-version-manager /repo/libs/cln-version-manager
-RUN cd /repo/libs/cln-version-manager; python -m pip install .
+RUN cd /repo/libs/cln-version-manager; python -m pip install -e .
 
-# RUN /tmp/venv/bin/python -m clnvm get -all
+RUN python -m clnvm get-all
 
 # -------------------------------------
 # STAGE: bitcoin-downloader
@@ -220,12 +220,8 @@ ENV RUST_LOG=gl_client=trace,tracing=warn,gl_signerproxy=trace,gl_plugin=trace,l
 ENV GRPC_ENABLE_FORK_SUPPORT=0
 
 # Install cln-versions
-COPY --from=cln-downloader /repo/cln-versions/ /opt/cln
-RUN ln -s /opt/cln/v23.08gl1 /opt/cln-latest
-ENV PATH=/opt/cln-latest/usr/local/bin:$PATH
-
-# Enumerate all versions that gl-testing should find
-ENV CLN_PATH=/opt/cln/v0.10.1/usr/local/bin/:/opt/cln/v0.10.2/usr/local/bin/:/opt/cln/v0.11.0.1/usr/local/bin/:/opt/cln/v0.11.2gl2/usr/local/bin/:/opt/cln/v22.11gl1/usr/local/bin/:/opt/cln/v23.05gl1/usr/local/bin/:/opt/cln/v23.08gl1/usr/local/bin/
+COPY --from=cln-downloader /opt/cln /opt/cln
+ENV CLNVM_CACHE_DIR=/opt/cln
 
 # Install bitcoin-core
 COPY --from=bitcoin-downloader /opt/bitcoin/bin /opt/bitcoin/bin
@@ -254,10 +250,6 @@ RUN groupadd -g $GID -o $DOCKER_USER &&\
     useradd -m -u $UID -g $GID -G sudo -o -s /bin/bash $DOCKER_USER && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Configure clnvm
-RUN mkdir -p /opt/clnvm; chmod a+rw /opt/clnvm
-ENV CLNVM_CACHE_DIR=/opt/clnvm
-
 # Create the required tmp-dicts
 RUN chmod a+rw /tmp
 RUN mkdir -p /tmp/gltesting/cargo && mkdir -p /tmp/gltesting/tmp
@@ -269,6 +261,9 @@ WORKDIR /repo
 RUN poetry install
 RUN chmod -R a+rw /tmp/venv
 
+# Create a symlink to the latest cln-version and add it to the path
+RUN ln -s $(clnvm latest --root-path) /opt/cln-latest
+ENV PATH=/opt/cln-latest/usr/local/bin:$PATH
 
 
 

--- a/libs/cln-version-manager/clnvm/cli.py
+++ b/libs/cln-version-manager/clnvm/cli.py
@@ -1,10 +1,19 @@
 import importlib
+import logging
+import logging.config
+from pathlib import Path
+
 import os
 import sys
 from typing import Optional
 
 import clnvm
 from clnvm.cln_version_manager import ClnVersionManager, VersionDescriptor
+
+def configure_logging():
+    dirname, _ = os.path.split(__file__)
+    breakpoint()
+    logging.config.fileConfig(Path(dirname) / "logging.conf")
 
 # Handle the optional import and provide a nice error message if it fails
 _click = importlib.util.find_spec("click")
@@ -18,8 +27,10 @@ import click
 
 
 @click.group()
-def cli() -> None:
-    pass
+@click.option("--verbose", is_flag=True)
+def cli(verbose: bool) -> None:
+    if verbose:
+        configure_logging()
 
 
 @cli.command()

--- a/libs/cln-version-manager/clnvm/cli.py
+++ b/libs/cln-version-manager/clnvm/cli.py
@@ -12,7 +12,7 @@ if _click is None:
     print("To use clnvm the `cli` feature must be installed")
     print("You can install the feature using")
     print("> pip install gltesting[cli]")
-    exit()
+    sys.exit(1)
 
 import click
 
@@ -33,6 +33,7 @@ def get_all(force: bool) -> None:
             click.echo(result.lightningd)
         except Exception as e:
             click.echo(click.style(str(e), fg="red"), err=True)
+            sys.exit(1)
 
 
 @cli.command()

--- a/libs/cln-version-manager/clnvm/cli.py
+++ b/libs/cln-version-manager/clnvm/cli.py
@@ -10,9 +10,8 @@ from typing import Optional
 import clnvm
 from clnvm.cln_version_manager import ClnVersionManager, VersionDescriptor
 
-def configure_logging():
+def configure_logging() -> None:
     dirname, _ = os.path.split(__file__)
-    breakpoint()
     logging.config.fileConfig(Path(dirname) / "logging.conf")
 
 # Handle the optional import and provide a nice error message if it fails

--- a/libs/cln-version-manager/clnvm/cln_version_manager.py
+++ b/libs/cln-version-manager/clnvm/cln_version_manager.py
@@ -67,7 +67,7 @@ CLN_VERSIONS = [
     VersionDescriptor(
         tag="v23.08gl1",
         url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v23.08gl1.tar.bz2",
-        checksum="724a5ae70e1e5fda67751a37dbb56648735b6d55394dcfe2193f15892c483d55",
+        checksum="0e392c5117e14dc37cf72393f47657a09821f69ab8b45937d7e79ca8d91d17e9",
     ),
 ]
 

--- a/libs/cln-version-manager/clnvm/cln_version_manager.py
+++ b/libs/cln-version-manager/clnvm/cln_version_manager.py
@@ -67,7 +67,7 @@ CLN_VERSIONS = [
     VersionDescriptor(
         tag="v23.08gl1",
         url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v23.08gl1.tar.bz2",
-        checksum="700e2f4765ba2f8d83ea26e0dc5b47c7176b665c7d6945bdfed2207c90ed9ebd",
+        checksum="724a5ae70e1e5fda67751a37dbb56648735b6d55394dcfe2193f15892c483d55",
     ),
 ]
 

--- a/libs/cln-version-manager/clnvm/cln_version_manager.py
+++ b/libs/cln-version-manager/clnvm/cln_version_manager.py
@@ -188,7 +188,7 @@ class ClnVersionManager:
             root_path=target_path,
         )
 
-    def _download(self, cln_version: VersionDescriptor, target_path: Path, verify_tag=False) -> None:
+    def _download(self, cln_version: VersionDescriptor, target_path: Path, verify_tag:bool = False) -> None:
         """Downloads the provided cln_version"""
         tag = cln_version.tag
         logger.info("Downloading version %s to %s", tag, target_path)

--- a/libs/cln-version-manager/clnvm/logging.conf
+++ b/libs/cln-version-manager/clnvm/logging.conf
@@ -1,0 +1,27 @@
+[loggers]
+keys=root,clnvm
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler
+
+[logger_clnvm]
+level=DEBUG
+handlers=consoleHandler
+qualname=clnvm
+propagate=0
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s


### PR DESCRIPTION
This is part of a bigger effort to make `gl-testing` a stand-alone package. One of the dependencies of `gl-testing` is a wide range of `lightningd`-executables.

The `cln_version_manager` can download these versions and provide them to `gl-testing`. I've introduced `cln_version_manger` before. This PR contains a couple of fixes and ensures `gl-testing` uses versions managed by `cln_version_manager`

- **cln_version_manager: Don't verify tag by default**
- **Rework Dockerfile to install binaries**
- **clnvm: Use non-zero exit code on error**
- **Add verbose option to cln_vm cli**
- **cln_version_manager: Use hash of patched version**
- **Use versions based on cln-version-manager**
- **Clean-up Makefile**
