### PR TITLE
derive Serialize and Deserialize on grpc requests/responses

### DIFF
--- a/libs/gl-client/build.rs
+++ b/libs/gl-client/build.rs
@@ -62,6 +62,7 @@ fn main() {
     let builder = tonic_build::configure();
 
     builder
+        .type_attribute(".", "#[derive(serde::Serialize,serde::Deserialize)]")
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile(
             &[


### PR DESCRIPTION
It's basically the same PR as this one https://github.com/ElementsProject/lightning/pull/7015
But for Greenlight.
This allows easy pretty printing of responses received from the node.