### PR TITLE
rs: Reorder the network enum to match the `bitcoin` crate's enumeration

### DIFF
--- a/libs/gl-testing/gltesting/utils.py
+++ b/libs/gl-testing/gltesting/utils.py
@@ -38,8 +38,12 @@ class SignerVersion:
 
 
 class Network(Enum):
-    """Supported networks."""
+    """Supported networks.
+
+    Matches the enum in the `bitcoin::Network` rust code.
+    """
 
     BITCOIN = 0
     TESTNET = 1
-    REGTEST = 2
+    SIGNET = 2
+    REGTEST = 3


### PR DESCRIPTION
We were investigating the switch from signet to regtest in the test
environment, and I misidentified the solution as being an ordering, or
numbering issue in the `enum`. Turns out we were using an altogether
different enum in the first place, and that was causing the
issue. Nevertheless, lining these up the same way should prevent
accidental breakage if we end up using the numeric encoding somewhere.

Fixes #434 
