### PR TITLE
client: Reduce noisy logging when creating TlsConfig from Credentials

### DIFF
--- a/libs/gl-client-py/src/credentials.rs
+++ b/libs/gl-client-py/src/credentials.rs
@@ -83,28 +83,28 @@ impl Credentials {
     #[new]
     pub fn new() -> Self {
         let inner = UnifiedCredentials::Nobody(gl_client::credentials::Nobody::default());
-        log::debug!("Created NOBODY credentials {:?}", inner.tls_config().client_tls_config());
+        log::debug!("Created NOBODY credentials");
         Self { inner }
     }
 
     #[staticmethod]
     pub fn nobody_with(cert: &[u8], key: &[u8], ca: &[u8]) -> Self {
         let inner = UnifiedCredentials::Nobody(gl_client::credentials::Nobody::with(cert, key, ca));
-        log::debug!("Created NOBODY credentials {:?}", inner.tls_config());
+        log::debug!("Created NOBODY credentials");
         Self { inner }
     }
 
     #[staticmethod]
     pub fn from_path(path: &str) -> Self {
         let inner = UnifiedCredentials::Device(gl_client::credentials::Device::from_path(path));
-        log::debug!("Created device credentials {:?}", inner.tls_config());
+        log::debug!("Created device credentials");
         Self { inner }
     }
 
     #[staticmethod]
     pub fn from_bytes(data: &[u8]) -> Self {
         let inner = UnifiedCredentials::Device(gl_client::credentials::Device::from_bytes(data));
-        log::debug!("Created device credentials {:?}", inner.tls_config());
+        log::debug!("Created device credentials");
         Self { inner }
     }
 

--- a/libs/gl-client/src/credentials.rs
+++ b/libs/gl-client/src/credentials.rs
@@ -131,7 +131,7 @@ impl Device {
     /// credentials data blob. It defaults to the nobody credentials set.
     pub fn from_bytes(data: impl AsRef<[u8]>) -> Self {
         let mut creds = Self::default();
-        debug!("Build authenticated credentials from: {:?}", data.as_ref());
+        log::trace!("Build authenticated credentials from: {:?}", data.as_ref());
         if let Ok(data) = model::Data::try_from(data.as_ref()) {
             creds.version = data.version;
             if let Some(cert) = data.cert {


### PR DESCRIPTION
It was spewing out pages of raw binary data every time, which was
drowning my shell. Reducing the build of the credentials to its type,
and logging the raw credentials onces but at a lower severity sounds
like a good idea.