### PR TITLE
CI: Do not install path-deps in `python-builder`

### DIFF
--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -73,7 +73,7 @@ WORKDIR repo
 # don't have the code in the Docker-repo yet.
 RUN poetry lock
 RUN poetry export -f requirements.txt -o requirements.txt --with=dev
-RUN cat requirements.txt | sed '/@ file:\/\/\//d' > requirements2.txt
+RUN cat requirements.txt | sed '/file:\/\/\//d' > requirements2.txt
 RUN python -m pip install --upgrade pip && pip install wheel && pip install -r requirements2.txt
 
 # Later we will run this image under another user


### PR DESCRIPTION
The `python-builder` is the first stage when building the Dockerfile.
It installs all python dependencies into a `venv`.

Installing dependencies is time-consuming and we want to cache this.
Therefore, we don't want to include the path-dependencies yet. If we
would add `gl-client` and `gl-testing` we would have to rebuild the
entire docker container every time we change a line in the code-base.

In the `python-builder` we first generate a list of dependencies using
`poetry export`. We filter out the path-dependencies of this list before
installing them.

However, the script to filter out the path-dependencies is broken. We
fail to filter out the path-dependencies. This modification fixes the
problem and ensures the pipeline runs again.
