### PR TITLE
Fix CI error: "AttributeError: channels"

### DIFF
--- a/libs/gl-client-py/glclient/__init__.py
+++ b/libs/gl-client-py/glclient/__init__.py
@@ -180,6 +180,15 @@ class Node(object):
         return res.FromString(
             bytes(self.inner.call(uri, bytes(req)))
         )
+    
+    def list_peer_channels(self) -> clnpb.ListpeerchannelsResponse:
+        uri = "/cln.Node/ListPeerChannels"
+        req = clnpb.ListpeerchannelsRequest().SerializeToString()
+        res = clnpb.ListpeerchannelsResponse
+
+        return res.FromString(
+            bytes(self.inner.call(uri, bytes(req)))
+        )
 
     def list_closed_channels(self) -> clnpb.ListclosedchannelsResponse:
         uri = "/cln.Node/ListClosedChannels"

--- a/libs/gl-testing/tests/test_node.py
+++ b/libs/gl-testing/tests/test_node.py
@@ -81,7 +81,8 @@ def test_node_network(node_factory, clients, bitcoind):
     bitcoind.generate_block(6, wait_for_mempool=1)
 
     # Now wait for the channel to confirm
-    wait_for(lambda: gl1.list_peers().peers[0].channels[0].state == 'CHANNELD_NORMAL')
+    wait_for(lambda: len(gl1.list_peer_channels().channels) > 0)
+    wait_for(lambda: gl1.list_peer_channels().channels[0].state ==  2) # CHANNELD_NORMAL
     wait_for(lambda: len(l1.rpc.listchannels()['channels']) == 2)
 
     inv = gl1.invoice(
@@ -163,7 +164,10 @@ def test_node_invoice_amountless(bitcoind, node_factory, clients):
         amount=clnpb.AmountOrAll(amount=clnpb.Amount(msat=10**9))
     )
     bitcoind.generate_block(6, wait_for_mempool=1)
-    wait_for(lambda: gl1.list_peers().peers[0].channels[0].state == 2)  # CHANNELD_NORMAL
+    
+    # the channels array is optional
+    wait_for(lambda: len(gl1.list_peer_channels().channels) > 0)
+    wait_for(lambda: gl1.list_peer_channels().channels[0].state ==  2)  # CHANNELD_NORMAL
 
     # Generate an invoice without amount:
     inv = l1.rpc.call('invoice', payload={
@@ -201,7 +205,10 @@ def test_node_listpays_preimage(clients, node_factory, bitcoind):
         amount=clnpb.AmountOrAll(amount=clnpb.Amount(msat=10**9))
     )
     bitcoind.generate_block(6, wait_for_mempool=1)
-    wait_for(lambda: gl1.list_peers().peers[0].channels[0].state == 2)  # CHANNELD_NORMAL
+
+    # the channels array is optional
+    wait_for(lambda: len(gl1.list_peer_channels().channels) > 0)
+    wait_for(lambda: gl1.list_peer_channels().channels[0].state ==  2)  # CHANNELD_NORMAL
 
     preimage = "00"*32
 


### PR DESCRIPTION
There are 2 open PRs that produce the same error `AttributeError: channels` on the following tests:
 - libs/gl-testing/tests/test_gl_node.py:127 test_configure_close_to_addr
 - libs/gl-testing/tests/test_node.py:143 test_node_invoice_amountless
 - libs/gl-testing/tests/test_node.py:186 test_node_listpays_preimage

It seems that the optional `channels` array returned by `listpeers` is not reliable anymore. This PR replaces the `listpeers` calls by `listpeerchannels` which will return a `channels` array.