### PR TITLE
build: added cargo config for pyo3 builds on mac.

### DIFF
--- a/libs/gl-client-py/.cargo/config.toml
+++ b/libs/gl-client-py/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
Added the configuration targets needed to build with pyo3 on mac:
https://pyo3.rs/v0.14.2/building_and_distribution.html#macos