### PR TITLE
rs: Pin the cln-grpc dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 [workspace.dependencies]
 anyhow = "1"
 env_logger = "0.10"
-cln-grpc = "0.1.8"
+cln-grpc = "=0.1.8"
 cln-rpc = "0.1.8"
 cln-plugin = "0.1.8"
 


### PR DESCRIPTION
When pulling greenlight version 0.2.0 in Rust, I got the following error:

```
randy@HOME gl % cargo build
   Compiling gl-client v0.2.0 (https://github.com/Blockstream/greenlight.git?rev=3a52042de220f1c6c3de171a6284c6d0177a5168#3a52042d)
error[E0412]: cannot find type `DelexpiredinvoiceRequest` in module `cln`
    --> /Users/randy/.cargo/git/checkouts/greenlight-e41cf58dbd255ee0/3a52042/libs/gl-client/src/signer/model/mod.rs:41:28
     |
41   |     DelExpiredInvoice(cln::DelexpiredinvoiceRequest),
     |                            ^^^^^^^^^^^^^^^^^^^^^^^^ help: a struct with a similar name exists: `DelinvoiceRequest`
     |
    ::: /Users/randy/Desktop/gldemo/gl/target/debug/build/cln-grpc-cdbfd96d73c34bc9/out/cln.rs:1800:1
     |
1800 | pub struct DelinvoiceRequest {
     | ---------------------------- similarly named struct `DelinvoiceRequest` defined here

error[E0433]: failed to resolve: use of undeclared type `DelexpiredinvoiceRequest`
  --> /Users/randy/.cargo/git/checkouts/greenlight-e41cf58dbd255ee0/3a52042/libs/gl-client/src/signer/model/cln.rs:27:62
   |
27 | ...quest::DelExpiredInvoice(DelexpiredinvoiceRequest::decode(p)?),
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^
   |                             |
   |                             use of undeclared type `DelexpiredinvoiceRequest`
   |                             help: a struct with a similar name exists: `DelinvoiceRequest`

error[E0599]: no method named `bolt11` found for reference `&cln_grpc::pb::PreapproveinvoiceRequest` in the current scope
  --> /Users/randy/.cargo/git/checkouts/greenlight-e41cf58dbd255ee0/3a52042/libs/gl-client/src/signer/resolve.rs:97:40
   |
97 |                     l.invstring.0 == r.bolt11().as_bytes()
   |                                        ^^^^^^-- help: remove the arguments
   |                                        |
   |                                        field, not a method
```


This is because gl-client pulls in cln-grpc 0.1.9 which contains the Core Lightning commit [7e0e39](https://github.com/ElementsProject/lightning/commit/7e0e39460b57ad05f05b426b229faabd63b18605) that removes the DelexpiredinvoiceRequest grpc model. This PR pins the cln-grpc version to 0.1.8 to avoid this breaking change until we're ready to update.