### PR TITLE
Temporarily ignore hashes in clnvm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ docker-image: ${REPO_ROOT}/docker/gl-testing/Dockerfile
 	  --build-arg DOCKER_USER=$(shell whoami) \
 	  --build-arg UID=$(shell id -u) \
 	  --build-arg GID=$(shell id -g) \
+	  --build-arg GL_TESTING_IGNORE_HASH=1 \
 	  -t gltesting \
 	  -f docker/gl-testing/Dockerfile \
 	  .

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -112,13 +112,15 @@ RUN chmod a+rwx -R $CARGO_HOME
 # Download all versions so they can be copied to our dev-container
 FROM python-builder as cln-downloader
 
+ARG GL_TESTING_IGNORE_HASH=0
+
 RUN mkdir -p /opt/cln/
 ENV CLNVM_CACHE_DIR=/opt/cln
 
 ADD libs/cln-version-manager /repo/libs/cln-version-manager
 RUN cd /repo/libs/cln-version-manager; python -m pip install -e .
 
-RUN python -m clnvm get-all
+RUN GL_TESTING_IGNORE_HASH=${GL_TESTING_IGNORE_HASH} python -m clnvm get-all
 
 # -------------------------------------
 # STAGE: bitcoin-downloader


### PR DESCRIPTION
We currently iterate quite fast on gl flavoured versions. With this commit we skip the check of the downloaded cln binary.