### PR TITLE
Revert "Upgrade cln-* crates"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,21 +536,17 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d528ade112e169cbb79ceae2f235b4502fee6e939326bbaa36aafcdfd54cd91c"
+checksum = "85b7b9e8de980dba797a0885b99fda797638d8a207089cb98710d94285e871df"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
  "cln-rpc",
- "futures-core",
  "hex",
  "log",
  "prost 0.11.9",
  "serde",
- "tokio 1.37.0",
- "tokio-stream",
- "tokio-util 0.7.11",
  "tonic 0.8.3",
  "tonic-build 0.8.4",
 ]
@@ -576,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974dac6f40275b7b828087f4f9973c39658f9b4a46cc589c083a2c6c27cf67cb"
+checksum = "2653217d27aee65a670f0c4f340b8f70b1f0b4e1c2fa085afe1b8e24ba12c069"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
@@ -3459,7 +3455,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.14",
  "tokio 1.37.0",
- "tokio-util 0.7.11",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "cln-plugin"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b096d2f2a7c58c6faaff1b64281a4c30ff078ec3ca746975fb76ac1a6d6e1f"
+checksum = "686c36c872fc3186f3c71650df64fdb4627de57291d39bdc80fe452155187391"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 env_logger = "0.10"
 cln-grpc = "0.1.9"
 cln-rpc = "0.1.9"
-cln-plugin = "0.1.9"
+cln-plugin = "0.1.8"
 
 vls-core = "^0.11.0"
 vls-persist = "^0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ members = [
 [workspace.dependencies]
 anyhow = "1"
 env_logger = "0.10"
-cln-grpc = "0.1.9"
-cln-rpc = "0.1.9"
+cln-grpc = "=0.1.8"
+cln-rpc = "0.1.8"
 cln-plugin = "0.1.8"
 
 vls-core = "^0.11.0"

--- a/libs/gl-client-py/glclient/rpc.py
+++ b/libs/gl-client-py/glclient/rpc.py
@@ -282,6 +282,19 @@ class Node(object):
             bytes(self.inner.call(uri, bytes(req)))
         )
 
+    def del_expired_invoice(
+            self,
+            maxexpirytime=None
+    ):
+        uri = "/cln.Node/DelExpiredInvoice"
+        req = clnpb.DelexpiredinvoiceRequest(
+            maxexpirytime=maxexpirytime
+        ).SerializeToString()
+        res = clnpb.DelexpiredinvoiceResponse
+        return res.FromString(
+            bytes(self.inner.call(uri, bytes(req)))
+        )
+
     def del_invoice(
             self,
             label,

--- a/libs/gl-client/src/signer/model/cln.rs
+++ b/libs/gl-client/src/signer/model/cln.rs
@@ -24,6 +24,7 @@ pub fn decode_request(uri: &str, p: &[u8]) -> anyhow::Result<Request> {
 	"/cln.Node/Datastore" => Request::Datastore(DatastoreRequest::decode(p)?),
 	"/cln.Node/CreateOnion" => Request::CreateOnion(CreateonionRequest::decode(p)?),
 	"/cln.Node/DelDatastore" => Request::DelDatastore(DeldatastoreRequest::decode(p)?),
+	"/cln.Node/DelExpiredInvoice" => Request::DelExpiredInvoice(DelexpiredinvoiceRequest::decode(p)?),
 	"/cln.Node/DelInvoice" => Request::DelInvoice(DelinvoiceRequest::decode(p)?),
 	"/cln.Node/Invoice" => Request::Invoice(InvoiceRequest::decode(p)?),
 	"/cln.Node/ListDatastore" => Request::ListDatastore(ListdatastoreRequest::decode(p)?),

--- a/libs/gl-client/src/signer/model/mod.rs
+++ b/libs/gl-client/src/signer/model/mod.rs
@@ -38,6 +38,7 @@ pub enum Request {
     Datastore(cln::DatastoreRequest),
     CreateOnion(cln::CreateonionRequest),
     DelDatastore(cln::DeldatastoreRequest),
+    DelExpiredInvoice(cln::DelexpiredinvoiceRequest),
     DelInvoice(cln::DelinvoiceRequest),
     Invoice(cln::InvoiceRequest),
     ListDatastore(cln::ListdatastoreRequest),

--- a/libs/gl-client/src/signer/resolve.rs
+++ b/libs/gl-client/src/signer/resolve.rs
@@ -99,7 +99,7 @@ impl Resolver {
                     // Manually calling preapproveinvoice should
                     // always be allowed. The bolt11 string have to
                     // match.
-                    l.invstring.0 == r.bolt11.as_bytes()
+                    l.invstring.0 == r.bolt11().as_bytes()
                 }
                 (_, _) => false,
             };

--- a/libs/gl-plugin/Cargo.toml
+++ b/libs/gl-plugin/Cargo.toml
@@ -21,7 +21,7 @@ base64 = "0.21.7"
 bytes = { version = "1", features = ["serde"] }
 clightningrpc = "0.2"
 cln-grpc = { workspace = true, features = ["server"] }
-cln-plugin = { workspace = true }
+cln-plugin = "^0.1"
 cln-rpc = { workspace = true }
 env_logger = "^0.7.1"
 futures = "0.3"

--- a/libs/gl-plugin/src/lib.rs
+++ b/libs/gl-plugin/src/lib.rs
@@ -158,9 +158,12 @@ async fn on_peer_connected(plugin: Plugin, v: serde_json::Value) -> Result<serde
 async fn on_openchannel(plugin: Plugin, v: serde_json::Value) -> Result<serde_json::Value> {
     debug!("Received an openchannel request: {:?}", v);
     let mut rpc = cln_rpc::ClnRpc::new(plugin.configuration().rpc_file).await?;
-
-    let req = cln_rpc::model::requests::ListdatastoreRequest {
-        key: Some(vec!["glconf".to_string(), "request".to_string()]),
+    
+    let req = cln_rpc::model::requests::ListdatastoreRequest{
+        key: Some(vec![
+            "glconf".to_string(),
+            "request".to_string(),
+        ])
     };
 
     let res = rpc.call_typed(&req).await;
@@ -171,17 +174,13 @@ async fn on_openchannel(plugin: Plugin, v: serde_json::Value) -> Result<serde_js
             if !res.datastore.is_empty() {
                 match &res.datastore[0].string {
                     Some(serialized_request) => {
-                        match _parse_gl_config_from_serialized_request(
-                            serialized_request.to_string(),
-                        ) {
+                        match _parse_gl_config_from_serialized_request(serialized_request.to_string()) {
                             Some(gl_config) => {
-                                return Ok(
-                                    json!({"result": "continue", "close_to":  gl_config.close_to_addr}),
-                                );
+                                return Ok(json!({"result": "continue", "close_to":  gl_config.close_to_addr}));
                             }
                             None => {
                                 debug!("Failed to parse the GlConfig from the serialized request's payload");
-                            }
+                            }  
                         }
                     }
                     None => {
@@ -190,13 +189,10 @@ async fn on_openchannel(plugin: Plugin, v: serde_json::Value) -> Result<serde_js
                 }
             }
 
-            return Ok(json!({"result": "continue"}));
+            return Ok(json!({"result": "continue"}))
         }
         Err(e) => {
-            log::debug!(
-                "An error occurred while searching for a custom close_to address: {}",
-                e
-            );
+            log::debug!("An error occurred while searching for a custom close_to address: {}", e);
             Ok(json!({"result": "continue"}))
         }
     }

--- a/libs/gl-plugin/src/node/mod.rs
+++ b/libs/gl-plugin/src/node/mod.rs
@@ -58,7 +58,6 @@ pub struct PluginNodeServer {
     pub rpc: Arc<Mutex<LightningClient>>,
     rpc_path: PathBuf,
     events: tokio::sync::broadcast::Sender<super::Event>,
-    notifications: tokio::sync::broadcast::Sender<cln_rpc::Notification>,
     signer_state: Arc<Mutex<State>>,
     grpc_binding: String,
     signer_state_store: Arc<Mutex<Box<dyn StateStore>>>,
@@ -99,8 +98,6 @@ impl PluginNodeServer {
 
         let rrpc = rpc.clone();
 
-        let (notifications, _) = tokio::sync::broadcast::channel(1);
-
         let s = PluginNodeServer {
             ctx,
             tls,
@@ -111,7 +108,6 @@ impl PluginNodeServer {
             signer_state: Arc::new(Mutex::new(signer_state)),
             signer_state_store: Arc::new(Mutex::new(signer_state_store)),
             grpc_binding: config.node_grpc_binding,
-            notifications,
         };
 
         tokio::spawn(async move {

--- a/libs/gl-plugin/src/node/wrapper.rs
+++ b/libs/gl-plugin/src/node/wrapper.rs
@@ -2,8 +2,6 @@ use crate::LightningClient;
 use anyhow::Error;
 use cln_grpc::pb::{self, node_server::Node};
 use log::debug;
-use tokio::sync::mpsc;
-use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tonic::{Request, Response, Status};
 
 use super::PluginNodeServer;
@@ -22,8 +20,7 @@ pub struct WrappedNodeServer {
 // TODO Make node into a module and add the WrappedNodeServer as a submodule.
 impl WrappedNodeServer {
     pub async fn new(node_server: PluginNodeServer) -> anyhow::Result<Self> {
-        let inner =
-            cln_grpc::Server::new(&node_server.rpc_path, node_server.notifications.clone()).await?;
+        let inner = cln_grpc::Server::new(&node_server.rpc_path).await?;
         Ok(WrappedNodeServer { inner, node_server })
     }
 }
@@ -32,170 +29,6 @@ impl WrappedNodeServer {
 // already...
 #[tonic::async_trait]
 impl Node for WrappedNodeServer {
-    async fn getinfo(
-        &self,
-        r: Request<pb::GetinfoRequest>,
-    ) -> Result<Response<pb::GetinfoResponse>, Status> {
-        self.inner.getinfo(r).await
-    }
-
-    async fn list_peers(
-        &self,
-        r: Request<pb::ListpeersRequest>,
-    ) -> Result<Response<pb::ListpeersResponse>, Status> {
-        self.inner.list_peers(r).await
-    }
-
-    async fn list_funds(
-        &self,
-        r: Request<pb::ListfundsRequest>,
-    ) -> Result<Response<pb::ListfundsResponse>, Status> {
-        self.inner.list_funds(r).await
-    }
-
-    async fn send_pay(
-        &self,
-        r: Request<pb::SendpayRequest>,
-    ) -> Result<Response<pb::SendpayResponse>, Status> {
-        self.inner.send_pay(r).await
-    }
-
-    async fn list_channels(
-        &self,
-        r: Request<pb::ListchannelsRequest>,
-    ) -> Result<Response<pb::ListchannelsResponse>, Status> {
-        self.inner.list_channels(r).await
-    }
-
-    async fn add_gossip(
-        &self,
-        r: Request<pb::AddgossipRequest>,
-    ) -> Result<Response<pb::AddgossipResponse>, Status> {
-        self.inner.add_gossip(r).await
-    }
-
-    async fn add_psbt_output(
-        &self,
-        r: tonic::Request<cln_grpc::pb::AddpsbtoutputRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::AddpsbtoutputResponse>, Status> {
-        self.inner.add_psbt_output(r).await
-    }
-
-    async fn auto_clean_invoice(
-        &self,
-        r: Request<pb::AutocleaninvoiceRequest>,
-    ) -> Result<Response<pb::AutocleaninvoiceResponse>, Status> {
-        self.inner.auto_clean_invoice(r).await
-    }
-
-    async fn auto_clean_once(
-        &self,
-        r: tonic::Request<cln_grpc::pb::AutocleanonceRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::AutocleanonceResponse>, Status> {
-        self.inner.auto_clean_once(r).await
-    }
-
-    async fn auto_clean_status(
-        &self,
-        r: tonic::Request<cln_grpc::pb::AutocleanstatusRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::AutocleanstatusResponse>, Status> {
-        self.inner.auto_clean_status(r).await
-    }
-
-    async fn check_message(
-        &self,
-        r: Request<pb::CheckmessageRequest>,
-    ) -> Result<Response<pb::CheckmessageResponse>, Status> {
-        self.inner.check_message(r).await
-    }
-
-    async fn close(
-        &self,
-        r: Request<pb::CloseRequest>,
-    ) -> Result<Response<pb::CloseResponse>, Status> {
-        self.inner.close(r).await
-    }
-    async fn connect_peer(
-        &self,
-        r: Request<pb::ConnectRequest>,
-    ) -> Result<Response<pb::ConnectResponse>, Status> {
-        self.inner.connect_peer(r).await
-    }
-
-    async fn create_invoice(
-        &self,
-        r: Request<pb::CreateinvoiceRequest>,
-    ) -> Result<Response<pb::CreateinvoiceResponse>, Status> {
-        self.inner.create_invoice(r).await
-    }
-
-    async fn datastore(
-        &self,
-        r: Request<pb::DatastoreRequest>,
-    ) -> Result<Response<pb::DatastoreResponse>, Status> {
-        self.inner.datastore(r).await
-    }
-
-    async fn datastore_usage(
-        &self,
-        r: Request<pb::DatastoreusageRequest>,
-    ) -> Result<Response<pb::DatastoreusageResponse>, Status> {
-        self.inner.datastore_usage(r).await
-    }
-
-    async fn create_onion(
-        &self,
-        r: Request<pb::CreateonionRequest>,
-    ) -> Result<Response<pb::CreateonionResponse>, Status> {
-        self.inner.create_onion(r).await
-    }
-
-    async fn del_datastore(
-        &self,
-        r: Request<pb::DeldatastoreRequest>,
-    ) -> Result<Response<pb::DeldatastoreResponse>, Status> {
-        self.inner.del_datastore(r).await
-    }
-
-    async fn del_invoice(
-        &self,
-        r: Request<pb::DelinvoiceRequest>,
-    ) -> Result<Response<pb::DelinvoiceResponse>, Status> {
-        self.inner.del_invoice(r).await
-    }
-
-    /// Is unimplemented as it is a dev command that is dangerous to use.
-    async fn dev_forget_channel(
-        &self,
-        _: tonic::Request<cln_grpc::pb::DevforgetchannelRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::DevforgetchannelResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "dev commands are not activated on greenlight",
-        ))
-    }
-
-    async fn emergency_recover(
-        &self,
-        r: tonic::Request<cln_grpc::pb::EmergencyrecoverRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::EmergencyrecoverResponse>, Status> {
-        self.inner.emergency_recover(r).await
-    }
-
-    async fn recover(
-        &self,
-        r: tonic::Request<cln_grpc::pb::RecoverRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::RecoverResponse>, Status> {
-        self.inner.recover(r).await
-    }
-
-    async fn recover_channel(
-        &self,
-        r: tonic::Request<cln_grpc::pb::RecoverchannelRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::RecoverchannelResponse>, Status> {
-        self.inner.recover_channel(r).await
-    }
-
     async fn invoice(
         &self,
         req: Request<pb::InvoiceRequest>,
@@ -263,25 +96,192 @@ impl Node for WrappedNodeServer {
         res.map(|r| Response::new(r))
     }
 
-    async fn create_invoice_request(
+    async fn getinfo(
         &self,
-        r: tonic::Request<cln_grpc::pb::InvoicerequestRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::InvoicerequestResponse>, Status> {
-        self.inner.create_invoice_request(r).await
+        r: Request<pb::GetinfoRequest>,
+    ) -> Result<Response<pb::GetinfoResponse>, Status> {
+        self.inner.getinfo(r).await
     }
 
-    async fn disable_invoice_request(
+    async fn list_offers(
         &self,
-        r: tonic::Request<cln_grpc::pb::DisableinvoicerequestRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::DisableinvoicerequestResponse>, Status> {
-        self.inner.disable_invoice_request(r).await
+        r: Request<pb::ListoffersRequest>,
+    ) -> Result<Response<pb::ListoffersResponse>, Status> {
+        self.inner.list_offers(r).await
     }
 
-    async fn list_invoice_requests(
+    async fn offer(
         &self,
-        r: tonic::Request<cln_grpc::pb::ListinvoicerequestsRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::ListinvoicerequestsResponse>, Status> {
-        self.inner.list_invoice_requests(r).await
+        r: Request<pb::OfferRequest>,
+    ) -> Result<Response<pb::OfferResponse>, Status> {
+        self.inner.offer(r).await
+    }
+
+    async fn bkpr_list_income(
+        &self,
+        r: Request<pb::BkprlistincomeRequest>,
+    ) -> Result<Response<pb::BkprlistincomeResponse>, Status> {
+        self.inner.bkpr_list_income(r).await
+    }
+
+    async fn list_peers(
+        &self,
+        r: Request<pb::ListpeersRequest>,
+    ) -> Result<Response<pb::ListpeersResponse>, Status> {
+        self.inner.list_peers(r).await
+    }
+
+    async fn list_peer_channels(
+        &self,
+        r: Request<pb::ListpeerchannelsRequest>,
+    ) -> Result<Response<pb::ListpeerchannelsResponse>, Status> {
+        self.inner.list_peer_channels(r).await
+    }
+
+    async fn list_closed_channels(
+        &self,
+        r: Request<pb::ListclosedchannelsRequest>,
+    ) -> Result<Response<pb::ListclosedchannelsResponse>, Status> {
+        self.inner.list_closed_channels(r).await
+    }
+
+    async fn list_funds(
+        &self,
+        r: Request<pb::ListfundsRequest>,
+    ) -> Result<Response<pb::ListfundsResponse>, Status> {
+        self.inner.list_funds(r).await
+    }
+
+    async fn decode_pay(
+        &self,
+        r: Request<pb::DecodepayRequest>,
+    ) -> Result<Response<pb::DecodepayResponse>, Status> {
+        self.inner.decode_pay(r).await
+    }
+
+    async fn decode(
+        &self,
+        r: Request<pb::DecodeRequest>,
+    ) -> Result<Response<pb::DecodeResponse>, Status> {
+        self.inner.decode(r).await
+    }
+
+    async fn sign_invoice(
+        &self,
+        r: Request<pb::SigninvoiceRequest>,
+    ) -> Result<Response<pb::SigninvoiceResponse>, Status> {
+        self.inner.sign_invoice(r).await
+    }
+    async fn pre_approve_keysend(
+        &self,
+        r: Request<pb::PreapprovekeysendRequest>,
+    ) -> Result<Response<pb::PreapprovekeysendResponse>, Status> {
+        self.inner.pre_approve_keysend(r).await
+    }
+
+    async fn pre_approve_invoice(
+        &self,
+        r: Request<pb::PreapproveinvoiceRequest>,
+    ) -> Result<Response<pb::PreapproveinvoiceResponse>, Status> {
+        self.inner.pre_approve_invoice(r).await
+    }
+
+    async fn send_custom_msg(
+        &self,
+        r: Request<pb::SendcustommsgRequest>,
+    ) -> Result<Response<pb::SendcustommsgResponse>, Status> {
+        self.inner.send_custom_msg(r).await
+    }
+
+    async fn send_pay(
+        &self,
+        r: Request<pb::SendpayRequest>,
+    ) -> Result<Response<pb::SendpayResponse>, Status> {
+        self.inner.send_pay(r).await
+    }
+
+    async fn list_channels(
+        &self,
+        r: Request<pb::ListchannelsRequest>,
+    ) -> Result<Response<pb::ListchannelsResponse>, Status> {
+        self.inner.list_channels(r).await
+    }
+
+    async fn add_gossip(
+        &self,
+        r: Request<pb::AddgossipRequest>,
+    ) -> Result<Response<pb::AddgossipResponse>, Status> {
+        self.inner.add_gossip(r).await
+    }
+
+    async fn auto_clean_invoice(
+        &self,
+        r: Request<pb::AutocleaninvoiceRequest>,
+    ) -> Result<Response<pb::AutocleaninvoiceResponse>, Status> {
+        self.inner.auto_clean_invoice(r).await
+    }
+
+    async fn check_message(
+        &self,
+        r: Request<pb::CheckmessageRequest>,
+    ) -> Result<Response<pb::CheckmessageResponse>, Status> {
+        self.inner.check_message(r).await
+    }
+
+    async fn close(
+        &self,
+        r: Request<pb::CloseRequest>,
+    ) -> Result<Response<pb::CloseResponse>, Status> {
+        self.inner.close(r).await
+    }
+
+    async fn connect_peer(
+        &self,
+        r: Request<pb::ConnectRequest>,
+    ) -> Result<Response<pb::ConnectResponse>, Status> {
+        self.inner.connect_peer(r).await
+    }
+
+    async fn create_invoice(
+        &self,
+        r: Request<pb::CreateinvoiceRequest>,
+    ) -> Result<Response<pb::CreateinvoiceResponse>, Status> {
+        self.inner.create_invoice(r).await
+    }
+
+    async fn datastore(
+        &self,
+        r: Request<pb::DatastoreRequest>,
+    ) -> Result<Response<pb::DatastoreResponse>, Status> {
+        self.inner.datastore(r).await
+    }
+
+    async fn create_onion(
+        &self,
+        r: Request<pb::CreateonionRequest>,
+    ) -> Result<Response<pb::CreateonionResponse>, Status> {
+        self.inner.create_onion(r).await
+    }
+
+    async fn del_datastore(
+        &self,
+        r: Request<pb::DeldatastoreRequest>,
+    ) -> Result<Response<pb::DeldatastoreResponse>, Status> {
+        self.inner.del_datastore(r).await
+    }
+
+    async fn del_expired_invoice(
+        &self,
+        r: Request<pb::DelexpiredinvoiceRequest>,
+    ) -> Result<Response<pb::DelexpiredinvoiceResponse>, Status> {
+        self.inner.del_expired_invoice(r).await
+    }
+
+    async fn del_invoice(
+        &self,
+        r: Request<pb::DelinvoiceRequest>,
+    ) -> Result<Response<pb::DelinvoiceResponse>, Status> {
+        self.inner.del_invoice(r).await
     }
 
     async fn list_datastore(
@@ -319,17 +319,6 @@ impl Node for WrappedNodeServer {
         self.inner.list_transactions(r).await
     }
 
-    // Is unimplemented as greenlight uses a custom signer.
-    async fn make_secret(
-        &self,
-        _: tonic::Request<cln_grpc::pb::MakesecretRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::MakesecretResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "make_secret is disabled on greenlight",
-        ))
-    }
-
     async fn pay(&self, r: Request<pb::PayRequest>) -> Result<Response<pb::PayResponse>, Status> {
         self.inner.pay(r).await
     }
@@ -360,6 +349,13 @@ impl Node for WrappedNodeServer {
         r: Request<pb::WaitsendpayRequest>,
     ) -> Result<Response<pb::WaitsendpayResponse>, Status> {
         self.inner.wait_send_pay(r).await
+    }
+
+    async fn wait_block_height(
+        &self,
+        r: Request<pb::WaitblockheightRequest>,
+    ) -> Result<Response<pb::WaitblockheightResponse>, Status> {
+        self.inner.wait_block_height(r).await
     }
 
     async fn new_addr(
@@ -432,55 +428,6 @@ impl Node for WrappedNodeServer {
         self.inner.tx_send(r).await
     }
 
-    async fn list_peer_channels(
-        &self,
-        r: Request<pb::ListpeerchannelsRequest>,
-    ) -> Result<Response<pb::ListpeerchannelsResponse>, Status> {
-        self.inner.list_peer_channels(r).await
-    }
-
-    async fn list_closed_channels(
-        &self,
-        r: Request<pb::ListclosedchannelsRequest>,
-    ) -> Result<Response<pb::ListclosedchannelsResponse>, Status> {
-        self.inner.list_closed_channels(r).await
-    }
-
-    async fn decode_pay(
-        &self,
-        r: Request<pb::DecodepayRequest>,
-    ) -> Result<Response<pb::DecodepayResponse>, Status> {
-        self.inner.decode_pay(r).await
-    }
-
-    async fn decode(
-        &self,
-        r: Request<pb::DecodeRequest>,
-    ) -> Result<Response<pb::DecodeResponse>, Status> {
-        self.inner.decode(r).await
-    }
-
-    async fn del_pay(
-        &self,
-        r: tonic::Request<cln_grpc::pb::DelpayRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::DelpayResponse>, Status> {
-        self.inner.del_pay(r).await
-    }
-
-    async fn del_forward(
-        &self,
-        r: tonic::Request<cln_grpc::pb::DelforwardRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::DelforwardResponse>, Status> {
-        self.inner.del_forward(r).await
-    }
-
-    async fn disable_offer(
-        &self,
-        r: tonic::Request<cln_grpc::pb::DisableofferRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::DisableofferResponse>, Status> {
-        self.inner.disable_offer(r).await
-    }
-
     async fn disconnect(
         &self,
         r: Request<pb::DisconnectRequest>,
@@ -515,53 +462,11 @@ impl Node for WrappedNodeServer {
         self.inner.feerates(r).await
     }
 
-    async fn fetch_invoice(
-        &self,
-        request: tonic::Request<pb::FetchinvoiceRequest>,
-    ) -> Result<tonic::Response<pb::FetchinvoiceResponse>, tonic::Status> {
-        self.inner.fetch_invoice(request).await
-    }
-
-    async fn fund_channel_cancel(
-        &self,
-        r: tonic::Request<cln_grpc::pb::FundchannelCancelRequest>,
-    ) -> Result<tonic::Response<pb::FundchannelCancelResponse>, Status> {
-        self.inner.fund_channel_cancel(r).await
-    }
-
-    async fn fund_channel_complete(
-        &self,
-        r: tonic::Request<cln_grpc::pb::FundchannelCompleteRequest>,
-    ) -> Result<tonic::Response<pb::FundchannelCompleteResponse>, Status> {
-        self.inner.fund_channel_complete(r).await
-    }
-
     async fn fund_channel(
         &self,
         r: Request<pb::FundchannelRequest>,
     ) -> Result<Response<pb::FundchannelResponse>, Status> {
         self.inner.fund_channel(r).await
-    }
-
-    async fn fund_channel_start(
-        &self,
-        r: tonic::Request<cln_grpc::pb::FundchannelStartRequest>,
-    ) -> Result<tonic::Response<pb::FundchannelStartResponse>, Status> {
-        self.inner.fund_channel_start(r).await
-    }
-
-    async fn get_log(
-        &self,
-        r: tonic::Request<cln_grpc::pb::GetlogRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::GetlogResponse>, Status> {
-        self.inner.get_log(r).await
-    }
-
-    async fn funder_update(
-        &self,
-        r: tonic::Request<cln_grpc::pb::FunderupdateRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::FunderupdateResponse>, Status> {
-        self.inner.funder_update(r).await
     }
 
     async fn get_route(
@@ -578,81 +483,11 @@ impl Node for WrappedNodeServer {
         self.inner.list_forwards(r).await
     }
 
-    async fn list_offers(
-        &self,
-        r: Request<pb::ListoffersRequest>,
-    ) -> Result<Response<pb::ListoffersResponse>, Status> {
-        self.inner.list_offers(r).await
-    }
-
     async fn list_pays(
         &self,
         r: Request<pb::ListpaysRequest>,
     ) -> Result<Response<pb::ListpaysResponse>, Status> {
         self.inner.list_pays(r).await
-    }
-
-    async fn list_htlcs(
-        &self,
-        r: Request<pb::ListhtlcsRequest>,
-    ) -> Result<Response<pb::ListhtlcsResponse>, Status> {
-        self.inner.list_htlcs(r).await
-    }
-
-    async fn multi_fund_channel(
-        &self,
-        r: tonic::Request<cln_grpc::pb::MultifundchannelRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::MultifundchannelResponse>, Status> {
-        self.inner.multi_fund_channel(r).await
-    }
-
-    async fn multi_withdraw(
-        &self,
-        r: tonic::Request<cln_grpc::pb::MultiwithdrawRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::MultiwithdrawResponse>, Status> {
-        self.inner.multi_withdraw(r).await
-    }
-
-    async fn offer(
-        &self,
-        r: Request<pb::OfferRequest>,
-    ) -> Result<Response<pb::OfferResponse>, Status> {
-        self.inner.offer(r).await
-    }
-
-    async fn open_channel_abort(
-        &self,
-        r: tonic::Request<cln_grpc::pb::OpenchannelAbortRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::OpenchannelAbortResponse>, Status> {
-        self.inner.open_channel_abort(r).await
-    }
-
-    async fn open_channel_bump(
-        &self,
-        r: tonic::Request<cln_grpc::pb::OpenchannelBumpRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::OpenchannelBumpResponse>, Status> {
-        self.inner.open_channel_bump(r).await
-    }
-
-    async fn open_channel_init(
-        &self,
-        r: tonic::Request<cln_grpc::pb::OpenchannelInitRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::OpenchannelInitResponse>, Status> {
-        self.inner.open_channel_init(r).await
-    }
-
-    async fn open_channel_signed(
-        &self,
-        r: tonic::Request<cln_grpc::pb::OpenchannelSignedRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::OpenchannelSignedResponse>, Status> {
-        self.inner.open_channel_signed(r).await
-    }
-
-    async fn open_channel_update(
-        &self,
-        r: tonic::Request<cln_grpc::pb::OpenchannelUpdateRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::OpenchannelUpdateResponse>, Status> {
-        self.inner.open_channel_update(r).await
     }
 
     async fn ping(
@@ -662,99 +497,11 @@ impl Node for WrappedNodeServer {
         self.inner.ping(r).await
     }
 
-    /// Is unimplemented as greenlight does not support plugins.
-    async fn plugin(
-        &self,
-        _: tonic::Request<cln_grpc::pb::PluginRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::PluginResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "plugins are not supported on greenlight",
-        ))
-    }
-
-    /// Is unimplemented as rene_pay is still experimental and under
-    /// development.
-    async fn rene_pay_status(
-        &self,
-        _: tonic::Request<cln_grpc::pb::RenepaystatusRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::RenepaystatusResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "rene_pay_status is dissabled on greenlight",
-        ))
-    }
-
-    /// Is unimplemented as rene_pay is still experimental and under
-    /// development.
-    async fn rene_pay(
-        &self,
-        _: tonic::Request<cln_grpc::pb::RenepayRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::RenepayResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "rene_pay is dissabled on greenlight",
-        ))
-    }
-
-    async fn reserve_inputs(
-        &self,
-        r: tonic::Request<cln_grpc::pb::ReserveinputsRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::ReserveinputsResponse>, Status> {
-        self.inner.reserve_inputs(r).await
-    }
-
-    async fn send_custom_msg(
-        &self,
-        r: Request<pb::SendcustommsgRequest>,
-    ) -> Result<Response<pb::SendcustommsgResponse>, Status> {
-        self.inner.send_custom_msg(r).await
-    }
-
-    async fn send_invoice(
-        &self,
-        r: tonic::Request<cln_grpc::pb::SendinvoiceRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::SendinvoiceResponse>, Status> {
-        self.inner.send_invoice(r).await
-    }
-
-    async fn send_onion_message(
-        &self,
-        r: tonic::Request<cln_grpc::pb::SendonionmessageRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::SendonionmessageResponse>, Status> {
-        self.inner.send_onion_message(r).await
-    }
-
     async fn set_channel(
         &self,
         r: Request<pb::SetchannelRequest>,
     ) -> Result<Response<pb::SetchannelResponse>, Status> {
         self.inner.set_channel(r).await
-    }
-
-    /// Is unimplemented as the config is set by greenlight.
-    async fn set_config(
-        &self,
-        _: tonic::Request<cln_grpc::pb::SetconfigRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::SetconfigResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "set_config is dissabled on greenlight",
-        ))
-    }
-
-    async fn set_psbt_version(
-        &self,
-        r: tonic::Request<cln_grpc::pb::SetpsbtversionRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::SetpsbtversionResponse>, Status> {
-        self.inner.set_psbt_version(r).await
-    }
-
-    async fn sign_invoice(
-        &self,
-        r: Request<pb::SigninvoiceRequest>,
-    ) -> Result<Response<pb::SigninvoiceResponse>, Status> {
-        self.inner.sign_invoice(r).await
     }
 
     async fn sign_message(
@@ -764,108 +511,11 @@ impl Node for WrappedNodeServer {
         self.inner.sign_message(r).await
     }
 
-    /// Is unimplemented as splicing it is still experimental.
-    async fn splice_init(
-        &self,
-        _: tonic::Request<cln_grpc::pb::SpliceInitRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::SpliceInitResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "splice_init is dissabled on greenlight",
-        ))
-    }
-
-    /// Is unimplemented as splicing it is still experimental.
-    async fn splice_signed(
-        &self,
-        _: tonic::Request<cln_grpc::pb::SpliceSignedRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::SpliceSignedResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "splice_signed is dissabled on greenlight",
-        ))
-    }
-
-    /// Is unimplemented as splicing it is still experimental.
-    async fn splice_update(
-        &self,
-        _: tonic::Request<cln_grpc::pb::SpliceUpdateRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::SpliceUpdateResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "splice_update is dissabled on greenlight",
-        ))
-    }
-
-    async fn unreserve_inputs(
-        &self,
-        r: tonic::Request<cln_grpc::pb::UnreserveinputsRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::UnreserveinputsResponse>, Status> {
-        self.inner.unreserve_inputs(r).await
-    }
-
-    /// Is unimplemented as greenlight does not have ps2h outputs.
-    async fn upgrade_wallet(
-        &self,
-        _: tonic::Request<cln_grpc::pb::UpgradewalletRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::UpgradewalletResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "upgrade_wallet is dissabled on greenlight",
-        ))
-    }
-
-    async fn wait_block_height(
-        &self,
-        r: Request<pb::WaitblockheightRequest>,
-    ) -> Result<Response<pb::WaitblockheightResponse>, Status> {
-        self.inner.wait_block_height(r).await
-    }
-
-    async fn wait(
-        &self,
-        request: tonic::Request<pb::WaitRequest>,
-    ) -> Result<tonic::Response<pb::WaitResponse>, tonic::Status> {
-        self.inner.wait(request).await
-    }
-
-    /// Is unimplemented as greenlight sets the config.
-    async fn list_configs(
-        &self,
-        _: tonic::Request<cln_grpc::pb::ListconfigsRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::ListconfigsResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "list_configs is dissabled on greenlight",
-        ))
-    }
-
     async fn stop(
         &self,
         r: Request<pb::StopRequest>,
     ) -> Result<Response<pb::StopResponse>, Status> {
         self.inner.stop(r).await
-    }
-
-    async fn help(
-        &self,
-        r: tonic::Request<cln_grpc::pb::HelpRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::HelpResponse>, Status> {
-        self.inner.help(r).await
-    }
-
-    async fn pre_approve_keysend(
-        &self,
-        r: Request<pb::PreapprovekeysendRequest>,
-    ) -> Result<Response<pb::PreapprovekeysendResponse>, Status> {
-        self.inner.pre_approve_keysend(r).await
-    }
-
-    async fn pre_approve_invoice(
-        &self,
-        r: Request<pb::PreapproveinvoiceRequest>,
-    ) -> Result<Response<pb::PreapproveinvoiceResponse>, Status> {
-        self.inner.pre_approve_invoice(r).await
     }
 
     async fn static_backup(
@@ -875,263 +525,32 @@ impl Node for WrappedNodeServer {
         self.inner.static_backup(r).await
     }
 
-    async fn bkpr_channels_apy(
+    async fn list_htlcs(
         &self,
-        r: tonic::Request<cln_grpc::pb::BkprchannelsapyRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::BkprchannelsapyResponse>, Status> {
-        self.inner.bkpr_channels_apy(r).await
+        r: Request<pb::ListhtlcsRequest>,
+    ) -> Result<Response<pb::ListhtlcsResponse>, Status> {
+        self.inner.list_htlcs(r).await
     }
 
-    async fn bkpr_dump_income_csv(
+    async fn datastore_usage(
         &self,
-        r: tonic::Request<cln_grpc::pb::BkprdumpincomecsvRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::BkprdumpincomecsvResponse>, Status> {
-        self.inner.bkpr_dump_income_csv(r).await
+        r: Request<pb::DatastoreusageRequest>,
+    ) -> Result<Response<pb::DatastoreusageResponse>, Status> {
+        self.inner.datastore_usage(r).await
     }
 
-    async fn bkpr_inspect(
+    async fn fetch_invoice(
         &self,
-        r: tonic::Request<cln_grpc::pb::BkprinspectRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::BkprinspectResponse>, Status> {
-        self.inner.bkpr_inspect(r).await
+        request: tonic::Request<pb::FetchinvoiceRequest>,
+    ) -> Result<tonic::Response<pb::FetchinvoiceResponse>, tonic::Status> {
+        self.inner.fetch_invoice(request).await
     }
 
-    async fn bkpr_list_account_events(
+    async fn wait(
         &self,
-        r: tonic::Request<cln_grpc::pb::BkprlistaccounteventsRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::BkprlistaccounteventsResponse>, Status> {
-        self.inner.bkpr_list_account_events(r).await
-    }
-
-    async fn bkpr_list_balances(
-        &self,
-        r: tonic::Request<cln_grpc::pb::BkprlistbalancesRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::BkprlistbalancesResponse>, Status> {
-        self.inner.bkpr_list_balances(r).await
-    }
-
-    async fn bkpr_list_income(
-        &self,
-        r: Request<pb::BkprlistincomeRequest>,
-    ) -> Result<Response<pb::BkprlistincomeResponse>, Status> {
-        self.inner.bkpr_list_income(r).await
-    }
-
-    /// Is unimplemented as runes need to be handled by gl-signer in
-    /// greenlight.
-    async fn blacklist_rune(
-        &self,
-        _: tonic::Request<cln_grpc::pb::BlacklistruneRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::BlacklistruneResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "blacklist_rune is dissabled on greenlight",
-        ))
-    }
-
-    /// Is unimplemented as runes need to be handled by gl-signer in
-    /// greenlight.
-    async fn check_rune(
-        &self,
-        _: tonic::Request<cln_grpc::pb::CheckruneRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::CheckruneResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "check_rune is dissabled on greenlight",
-        ))
-    }
-
-    /// Is unimplemented as runes need to be handled by gl-signer in
-    /// greenlight.
-    async fn create_rune(
-        &self,
-        _: tonic::Request<cln_grpc::pb::CreateruneRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::CreateruneResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "create_rune is dissabled on greenlight",
-        ))
-    }
-
-    /// Is unimplemented as runes need to be handled by gl-signer in
-    /// greenlight.
-    async fn show_runes(
-        &self,
-        _: tonic::Request<cln_grpc::pb::ShowrunesRequest>,
-    ) -> Result<tonic::Response<cln_grpc::pb::ShowrunesResponse>, Status> {
-        Err(Status::new(
-            tonic::Code::Unimplemented,
-            "show_runes is dissabled on greenlight",
-        ))
-    }
-
-    type SubscribeBlockAddedStream =
-        ReceiverStream<Result<cln_grpc::pb::BlockAddedNotification, Status>>;
-
-    async fn subscribe_block_added(
-        &self,
-        r: tonic::Request<cln_grpc::pb::StreamBlockAddedRequest>,
-    ) -> Result<tonic::Response<Self::SubscribeBlockAddedStream>, Status> {
-        // Fixme in cln_grpc (nepet):
-        // Workaround since the custom type NotificationStream is not
-        // publically accessible and can not be set as
-        // `type SubscribeBlockAddedStream`.
-        let mut inner_stream = self.inner.subscribe_block_added(r).await?.into_inner();
-        let (tx, rx) = mpsc::channel(10);
-
-        tokio::spawn(async move {
-            while let Some(result) = inner_stream.next().await {
-                let msg = match result {
-                    Ok(note) => Ok(note),
-                    Err(e) => {
-                        debug!("got an error listening to block_added notifications {e}");
-                        Err(e)
-                    }
-                };
-                if let Err(e) = tx.send(msg.clone()).await {
-                    debug!("failed to send notification {:?} to client {}", msg, e);
-                    return;
-                };
-            }
-        });
-
-        Ok(tonic::Response::new(rx.into()))
-    }
-
-    type SubscribeChannelOpenFailedStream =
-        ReceiverStream<Result<cln_grpc::pb::ChannelOpenFailedNotification, Status>>;
-
-    async fn subscribe_channel_open_failed(
-        &self,
-        r: tonic::Request<cln_grpc::pb::StreamChannelOpenFailedRequest>,
-    ) -> Result<tonic::Response<Self::SubscribeChannelOpenFailedStream>, Status> {
-        // Fixme in cln_grpc (nepet):
-        // Workaround since the custom type NotificationStream is not
-        // publically accessible and can not be set as
-        // `type SubscribeChannelOpenFailedStream`.
-        let mut inner_stream = self
-            .inner
-            .subscribe_channel_open_failed(r)
-            .await?
-            .into_inner();
-        let (tx, rx) = mpsc::channel(10);
-
-        tokio::spawn(async move {
-            while let Some(result) = inner_stream.next().await {
-                let msg = match result {
-                    Ok(note) => Ok(note),
-                    Err(e) => {
-                        debug!("got an error listening to channel_open_failed notifications {e}");
-                        Err(e)
-                    }
-                };
-                if let Err(e) = tx.send(msg.clone()).await {
-                    debug!("failed to send notification {:?} to client {}", msg, e);
-                    return;
-                };
-            }
-        });
-
-        Ok(tonic::Response::new(rx.into()))
-    }
-
-    type SubscribeChannelOpenedStream =
-        ReceiverStream<Result<cln_grpc::pb::ChannelOpenedNotification, Status>>;
-
-    async fn subscribe_channel_opened(
-        &self,
-        r: tonic::Request<cln_grpc::pb::StreamChannelOpenedRequest>,
-    ) -> Result<tonic::Response<Self::SubscribeChannelOpenedStream>, Status> {
-        // Fixme in cln_grpc (nepet):
-        // Workaround since the custom type NotificationStream is not
-        // publically accessible and can not be set as
-        // `type SubscribeChannelOpenedStream`.
-        let mut inner_stream = self.inner.subscribe_channel_opened(r).await?.into_inner();
-        let (tx, rx) = mpsc::channel(10);
-
-        tokio::spawn(async move {
-            while let Some(result) = inner_stream.next().await {
-                let msg = match result {
-                    Ok(note) => Ok(note),
-                    Err(e) => {
-                        debug!("got an error listening to channel_opened notifications {e}");
-                        Err(e)
-                    }
-                };
-                if let Err(e) = tx.send(msg.clone()).await {
-                    debug!("failed to send notification {:?} to client {}", msg, e);
-                    return;
-                };
-            }
-        });
-
-        Ok(tonic::Response::new(rx.into()))
-    }
-
-    type SubscribeConnectStream =
-        ReceiverStream<Result<cln_grpc::pb::PeerConnectNotification, Status>>;
-
-    async fn subscribe_connect(
-        &self,
-        r: tonic::Request<cln_grpc::pb::StreamConnectRequest>,
-    ) -> Result<tonic::Response<Self::SubscribeConnectStream>, Status> {
-        // Fixme in cln_grpc (nepet):
-        // Workaround since the custom type NotificationStream is not
-        // publically accessible and can not be set as
-        // `type SubscribeConnectStream`.
-        let mut inner_stream = self.inner.subscribe_connect(r).await?.into_inner();
-        let (tx, rx) = mpsc::channel(10);
-
-        tokio::spawn(async move {
-            while let Some(result) = inner_stream.next().await {
-                let msg = match result {
-                    Ok(note) => Ok(note),
-                    Err(e) => {
-                        debug!("got an error listening to connect notifications {e}");
-                        Err(e)
-                    }
-                };
-                if let Err(e) = tx.send(msg.clone()).await {
-                    debug!("failed to send notification {:?} to client {}", msg, e);
-                    return;
-                };
-            }
-        });
-
-        Ok(tonic::Response::new(rx.into()))
-    }
-
-    type SubscribeCustomMsgStream =
-        ReceiverStream<Result<cln_grpc::pb::CustomMsgNotification, Status>>;
-
-    async fn subscribe_custom_msg(
-        &self,
-        r: tonic::Request<cln_grpc::pb::StreamCustomMsgRequest>,
-    ) -> Result<tonic::Response<Self::SubscribeCustomMsgStream>, Status> {
-        // Fixme in cln_grpc (nepet):
-        // Workaround since the custom type NotificationStream is not
-        // publically accessible and can not be set as
-        // `type SubscribeCustomMsgStream`.
-        let mut inner_stream = self.inner.subscribe_custom_msg(r).await?.into_inner();
-        let (tx, rx) = mpsc::channel(10);
-
-        tokio::spawn(async move {
-            while let Some(result) = inner_stream.next().await {
-                let msg = match result {
-                    Ok(note) => Ok(note),
-                    Err(e) => {
-                        debug!("got an error listening to custom_msg notifications {e}");
-                        Err(e)
-                    }
-                };
-                if let Err(e) = tx.send(msg.clone()).await {
-                    debug!("failed to send notification {:?} to client {}", msg, e);
-                    return;
-                };
-            }
-        });
-
-        Ok(tonic::Response::new(rx.into()))
+        request: tonic::Request<pb::WaitRequest>,
+    ) -> Result<tonic::Response<pb::WaitResponse>, tonic::Status> {
+        self.inner.wait(request).await
     }
 }
 
@@ -1204,7 +623,7 @@ impl WrappedNodeServer {
                 pb::Routehint {
                     hops: vec![pb::RouteHop {
                         id: hex::decode(i.id).expect("hex-decoding node_id"),
-                        scid: aliases
+                        short_channel_id: aliases
                             .get(&i.short_channel_id)
                             .or(Some(&i.short_channel_id))
                             .unwrap()
@@ -1223,6 +642,7 @@ use crate::pb::{
     node_server::Node as GlNode, Custommsg, Empty, HsmRequest, HsmResponse, IncomingPayment,
     LogEntry, StreamCustommsgRequest, StreamIncomingFilter, StreamLogRequest,
 };
+use tokio_stream::wrappers::ReceiverStream;
 
 #[tonic::async_trait]
 impl GlNode for WrappedNodeServer {

--- a/libs/gl-plugin/src/pb.rs
+++ b/libs/gl-plugin/src/pb.rs
@@ -753,7 +753,7 @@ impl From<RouteHop> for requests::RoutehintHopDev {
     fn from(r: RouteHop) -> requests::RoutehintHopDev {
         requests::RoutehintHopDev {
             id: hex::encode(r.id),
-            short_channel_id: r.scid,
+            short_channel_id: r.short_channel_id,
             fee_base_msat: r.feebase.map(|f| f.msat).unwrap(),
             fee_proportional_millionths: r.feeprop,
             cltv_expiry_delta: r.expirydelta as u16,


### PR DESCRIPTION
We postpone upgrading the cln-* crates to the next general upgrade of the signer and node version. Reverting this ensures that we can publish updates on the server side without droping support for older nodes too early.

Reverts Blockstream/greenlight#472