### PR TITLE
signer: Pass policy rejections back to the node

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -99,7 +99,7 @@ jobs:
         path: libs/gl-client-py/dist/
 
   macos:
-    runs-on: macos-11
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:

--- a/libs/gl-client/.resources/proto/glclient/greenlight.proto
+++ b/libs/gl-client/.resources/proto/glclient/greenlight.proto
@@ -69,6 +69,12 @@ message HsmResponse {
 	// A list of updated key-value-version tuples that is to be
 	// merged into the state tracked by the plugin.
 	repeated SignerStateEntry signer_state = 5;
+
+	// If the signer reported an error, and did therefore not include
+	// `raw`, this is the stringified error, so we can print it in the
+	// logs. This should help us collate policy errors with the changes
+	// proposed by CLN
+	string error = 6;
 }
 
 message HsmRequest {

--- a/libs/gl-plugin/src/hsm.rs
+++ b/libs/gl-plugin/src/hsm.rs
@@ -63,6 +63,7 @@ impl Hsm for StagingHsmServer {
                 request_id: req.request_id,
                 raw: response,
                 signer_state: Vec::new(),
+                error: "".into(),
             }));
         } else if req.get_type() == 11 {
             debug!("Returning stashed init msg: {:?}", self.node_info.initmsg);
@@ -70,6 +71,7 @@ impl Hsm for StagingHsmServer {
                 request_id: req.request_id,
                 raw: self.node_info.initmsg.clone(),
                 signer_state: Vec::new(), // the signerproxy doesn't care about state
+                error: "".into(),
             }));
         } else if req.get_type() == 33 {
             debug!("Returning stashed dev-memleak response");
@@ -77,13 +79,14 @@ impl Hsm for StagingHsmServer {
                 request_id: req.request_id,
                 raw: vec![0, 133, 0],
                 signer_state: Vec::new(), // the signerproxy doesn't care about state
+                error: "".into(),
             }));
         }
 
         let mut chan = match self.stage.send(req).await {
             Err(e) => {
                 return Err(Status::unknown(format!(
-                    "Error while queing request from node: {:?}",
+                    "Error while queuing request from node: {:?}",
                     e
                 )))
             }

--- a/libs/gl-plugin/src/node/mod.rs
+++ b/libs/gl-plugin/src/node/mod.rs
@@ -394,6 +394,13 @@ impl Node for PluginNodeServer {
         request: Request<pb::HsmResponse>,
     ) -> Result<Response<pb::Empty>, Status> {
         let req = request.into_inner();
+
+	if req.error != "" {
+	    log::error!("Signer reports an error: {}", req.error);
+	    log::warn!("The above error was returned instead of a response.");
+	    return Ok(Response::new(pb::Empty::default()));
+	}
+
         // Create a state from the key-value-version tuples. Need to
         // convert here, since `pb` is duplicated in the two different
         // crates.

--- a/libs/gl-plugin/src/stager.rs
+++ b/libs/gl-plugin/src/stager.rs
@@ -176,6 +176,7 @@ mod test {
                         request_id: r.request.request_id,
                         raw: vec![],
                         signer_state: vec![],
+                        error: "".into(),
                     })
                     .await
                 {
@@ -194,6 +195,7 @@ mod test {
                         request_id: r.request.request_id,
                         raw: vec![],
                         signer_state: vec![],
+                        error: "".into(),
                     })
                     .await
                 {

--- a/libs/proto/glclient/greenlight.proto
+++ b/libs/proto/glclient/greenlight.proto
@@ -69,6 +69,12 @@ message HsmResponse {
 	// A list of updated key-value-version tuples that is to be
 	// merged into the state tracked by the plugin.
 	repeated SignerStateEntry signer_state = 5;
+
+	// If the signer reported an error, and did therefore not include
+	// `raw`, this is the stringified error, so we can print it in the
+	// logs. This should help us collate policy errors with the changes
+	// proposed by CLN
+	string error = 6;
 }
 
 message HsmRequest {


### PR DESCRIPTION
When the signer rejects a request we had no indication as to what went
wrong until now. With this change we (a) send back the error as if it
were a normal response and then (b) print the error in the logs,
allowing us to collate the operations causing the rejection with the
rejection itself.