### PR TITLE
Derive "Debug" for PairingSessionData

### DIFF
--- a/libs/gl-client/src/pairing/mod.rs
+++ b/libs/gl-client/src/pairing/mod.rs
@@ -23,6 +23,8 @@ pub enum Error {
     #[error("could not verify pairing data: {0}")]
     VerifyPairingDataError(String),
 }
+
+#[derive(Debug)]
 pub enum PairingSessionData {
     PairingResponse(PairDeviceResponse),
     PairingQr(String),


### PR DESCRIPTION
If used with tokio::sync::mpsc `SendError` requires PairingSessionData to implement std::fmt::Debug. Clippy is complining about this.

Resolves #500 