### PR TITLE
Trampoline: Return payment_hash as bytes directly

### DIFF
--- a/libs/gl-client-py/tests/test_plugin.py
+++ b/libs/gl-client-py/tests/test_plugin.py
@@ -89,6 +89,7 @@ def test_trampoline_pay(bitcoind, clients, node_factory):
 
     res = n1.trampoline_pay(inv["bolt11"], bytes.fromhex(l2.info["id"]))
     assert res
+    assert len(res.payment_hash) == 32 # There was a confusion about hex/bytes return.
 
     l2.rpc.unsetchecks()
 


### PR DESCRIPTION
Trampoline pay returned the `payment_hash` hex encoded instead of raw bytes as other grpc calls do.