### PR TITLE
testing: Update cryptograhy to newer version

### DIFF
--- a/libs/gl-testing/pyproject.toml
+++ b/libs/gl-testing/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-cryptography = ">=36.0.1,<37.0.0"
+cryptography = ">=36.0.1"
 ephemeral-port-reserve = "^1.1.4"
 sh = "^1.14.2"
 pytest-timeout = "^2.1.0"


### PR DESCRIPTION
The old version pattern was too restrictive to be useful.
