### PR TITLE
test: Rename gltesting to gl-testing

### DIFF
--- a/libs/gl-testing/pyproject.toml
+++ b/libs/gl-testing/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "gltesting"
+name = "gl-testing"
 version = "0.2.0"
 description = ""
 authors = ["Christian Decker <decker@blockstream.com>"]


### PR DESCRIPTION
The package name was `gltesting` rather than `gl-testing`, which is
the scheme we adopted almost everywhere. Rename to match.