### PR TITLE
Ensure signer doesn't exit on connection change

### DIFF
--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -504,7 +504,7 @@ impl Signer {
                 msg: e.to_string(),
                 request: Some(req.clone()),
                 git_version: GITHASH.to_string(),
-		node_id: self.node_id(),
+                node_id: self.node_id(),
             })
             .await;
             #[cfg(not(feature = "permissive"))]
@@ -569,7 +569,7 @@ impl Signer {
                 msg: format!("{:?}", e),
                 request: Some(req.clone()),
                 git_version: GITHASH.to_string(),
-		node_id: self.node_id(),
+                node_id: self.node_id(),
             })
             .await;
             return Err(Error::Other(anyhow!("processing request: {e:?}")));
@@ -816,6 +816,17 @@ impl Signer {
     }
 
     async fn run_forever_scheduler(
+        &self,
+        scheduler: SchedulerClient<tonic::transport::Channel>,
+    ) -> Result<(), anyhow::Error> {
+        loop {
+            if let Err(e) = self.run_once_scheduler(scheduler.clone()).await {
+                warn!("Error running schduler, trying again: {e}");
+            }
+        }
+    }
+
+    async fn run_once_scheduler(
         &self,
         mut scheduler: SchedulerClient<tonic::transport::Channel>,
     ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
We have noticed that when changing a network while greenlight (using breez sdk) is running we no longer able to create an invoice.
Digging into this I have noticed the signer exists with these logs:

```
[2024-10-06 14:26:41.256 DEBUG tonic::codec::decode:204] decoder inner stream error: Status { code: Unknown, message: "error reading a body from connection: address not available", source: Some(hyper::Error(Body, Error { kind: Io(Kind(AddrNotAvailable)) })) }
[2024-10-06 14:26:41.256 DEBUG gl_client::signer:855] Got an error from the scheduler status: Unknown, message: "error reading a body from connection: address not available", details: [], metadata: MetadataMap { headers: {} }
[2024-10-06 14:26:41.256 ERROR gl_client::signer:807] Scheduler signer loop exited unexpectedly: Err(Scheduler stream error Status { code: Unknown, message: "error reading a body from connection: address not available", source: Some(hyper::Error(Body, Error { kind: Io(Kind(AddrNotAvailable)) })) })
[2024-10-06 14:26:41.257 INFO gl_client::signer:812] Exiting the signer loop
[2024-10-06 14:26:41.257 INFO breez_sdk_core::greenlight::node_api:1220] signer exited gracefully

```
This PR ensures the signer won't exit and will indeed run forever as intended.
The same approach of `run_forever_inner` was applied to `run_forever_scheduler`

Note: while this prevents the signer from exiting and allow the app to recover there is still a gap of ~3 minutes before the new connected signer is receiving messages. Because I clearly see that after the fix the local signer reconnects successfully  I wonder if some keep alive settings on the backend side makes the scheduler "think" the old signer is still connected...