### PR TITLE
signer: Relax two rules to be warnings only

### DIFF
--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -130,6 +130,7 @@ impl Signer {
             rules: vec![
                 FilterRule::new_warn("policy-channel-safe-type-anchors"),
                 FilterRule::new_warn("policy-routing-balanced"),
+                FilterRule::new_warn("policy-commitment-retry-same"),
             ],
         });
 
@@ -138,6 +139,16 @@ impl Signer {
             rules: vec![
                 FilterRule::new_warn("policy-routing-balanced"),
                 FilterRule::new_warn("policy-htlc-fee-range"),
+            ],
+        });
+
+        // TODO: Remove once we found the desync issue
+        policy.filter.merge(PolicyFilter {
+            rules: vec![
+                // "policy failure: get_per_commitment_secret: cannot
+                // revoke commitment_number 312 when
+                // next_holder_commit_num is 313"
+                FilterRule::new_warn("policy-revoke-new-commitment-signed"),
             ],
         });
 


### PR DESCRIPTION
We need to accept repeat signature requests and revocations for older
states because the signer state update and the CLN state update are
not atomic, i.e., the signer commits first, therefore ratchets up,
before CLN stores its state, meaning we could potentially replay some
prior state due to a preemption and restart inbetween. Relaxing these
two should address the majority of our desync issue.
