### PR TITLE
enable trampoline for zero conf channels

### DIFF
--- a/libs/gl-plugin/src/tramp.rs
+++ b/libs/gl-plugin/src/tramp.rs
@@ -140,7 +140,8 @@ pub async fn trampolinepay(
         .unwrap_or_default()
         .into_iter()
         .filter_map(|ch| {
-            let short_channel_id = match ch.short_channel_id {
+            let short_channel_id = ch.short_channel_id.or(ch.alias.and_then(|a| a.local));
+            let short_channel_id = match short_channel_id {
                 Some(scid) => scid,
                 None => {
                     warn!("Missing short channel id on a channel to {}", &node_id);


### PR DESCRIPTION
If the channel is unconfirmed it doesn't have a short_channel_id, but it does have a local alias. Include unconfirmed channels in the channel filter by initializing the `AwaitableChannel` with either the `short_channel_id` or the local alias. `AwaitableChannel` already works with the alias as well. 