### PR TITLE
Temporarily disable armv7 build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,7 +47,8 @@ jobs:
 # aarch64 does not compile due to an old(-ish) compiler with the error
 #  `ARM assembler must define __ARM_ARCH`
 #        - aarch64
-        - armv7
+        # Temporarily disable armv7 as to github issues fetching a manifest for the architecture.
+        # - armv7
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Temporarily disable the armv7 build for `gl-client-py` as github seems to have issues with this architecture at the moment.