### PR TITLE
glclientpy: Upgrade protobuf dependencies

### DIFF
--- a/libs/gl-client-py/pyproject.toml
+++ b/libs/gl-client-py/pyproject.toml
@@ -28,13 +28,13 @@ black = "^23.1.0"
 mypy-protobuf = "^3.5"
 maturin = {version = ">=1.0,<1.3.2", extras = ["patchelf"]}
 mypy = "^1.7.0"
-grpcio-tools = "^1.59.2"
+grpcio-tools = "^1.67"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
-grpcio = ">=1.56"
+grpcio = ">=1.67"
 pyln-grpc-proto = ">=0.1.2,<1.2"
-protobuf = ">=3"
+protobuf = ">=4"
 maturin = ">=1.0"
 
 [build-system]

--- a/libs/gl-testing/gltesting/grpcweb.py
+++ b/libs/gl-testing/gltesting/grpcweb.py
@@ -180,7 +180,6 @@ class NodeHandler(Handler):
         # Load TLS client cert info client
         ctx = httpx.create_ssl_context(
             verify=ca_path,
-            http2=True,
             cert=(
                 node.identity.cert_chain_path,
                 node.identity.private_key_path,


### PR DESCRIPTION
The generated files have a minimum dependency for the runtime of 1.67, so lets reflect that in the requirements.