### PR TITLE
client: Tweak the keepalive interval and timeout

### DIFF
--- a/libs/gl-client/src/lib.rs
+++ b/libs/gl-client/src/lib.rs
@@ -70,7 +70,7 @@ pub use lightning_signer::bitcoin;
 pub use lightning_signer::lightning;
 pub use lightning_signer::lightning_invoice;
 
-pub(crate) const TCP_KEEPALIVE: Duration = Duration::from_secs(5);
-pub(crate) const TCP_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(90);
+pub(crate) const TCP_KEEPALIVE: Duration = Duration::from_secs(1);
+pub(crate) const TCP_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub mod runes;


### PR DESCRIPTION
As reported by the Breez team the cause for the `transport error` when
attempting a `trampoline_pay` appears to be that even short
interruptions in connectivity kill the TCP connections. The long 90s
timeout is causing `gl-client` to patiently sit there for the 90s,
ignoring all errors in the hope of getting the TCP connection
back. When it then attempts to re-establish the connection, any
pending call gets the dreaded `transport error`.

Reducing this to 5 seconds timeout and a 1s interval should minimize
the chances of issuing a command during the broken phase.

Suggested-by: Roei Erez <@roeierez>
Suggested-by: Jesse De Wit <@JssDWt>
Closes #428 