### PR TITLE
github CI: actions/upload-artifact@v4 update

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,23 +18,23 @@ jobs:
   source:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-        architecture: x64
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          architecture: x64
 
-    - run: pip3 install poetry
-    - run : |
-        cd libs/gl-client-py
-        poetry build --format=sdist
+      - run: pip3 install poetry
+      - run: |
+          cd libs/gl-client-py
+          poetry build --format=sdist
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: wheels
-        path: libs/gl-client-py/dist/gl_client-*.tar.gz
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-source
+          path: libs/gl-client-py/dist/gl_client-*.tar.gz
 
   linux:
     runs-on: ubuntu-20.04
@@ -42,62 +42,62 @@ jobs:
       fail-fast: false
       matrix:
         target:
-        - x86_64
-        - i686
-# aarch64 does not compile due to an old(-ish) compiler with the error
-#  `ARM assembler must define __ARM_ARCH`
-#        - aarch64
-        # Temporarily disable armv7 as to github issues fetching a manifest for the architecture.
-        # - armv7
+          - x86_64
+          - i686
+    # aarch64 does not compile due to an old(-ish) compiler with the error
+    #  `ARM assembler must define __ARM_ARCH`
+    #        - aarch64
+    # Temporarily disable armv7 as to github issues fetching a manifest for the architecture.
+    # - armv7
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v2
-      with:
-        version: "23.2"  # Fixed since we mount the path below
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.2" # Fixed since we mount the path below
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build wheels
-      uses: PyO3/maturin-action@v1
-      with:
-        working-directory: libs/gl-client-py
-        rust-toolchain: stable
-        target: ${{ matrix.target }}
-        manylinux: auto
-        args: --release --out dist
-        docker-options: -v /opt/hostedtoolcache/protoc/v23.2/x64/bin/protoc:/usr/bin/protoc:ro
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: libs/gl-client-py
+          rust-toolchain: stable
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: --release --out dist
+          docker-options: -v /opt/hostedtoolcache/protoc/v23.2/x64/bin/protoc:/usr/bin/protoc:ro
 
-    - name: Install built wheel (emulated)
-      uses: uraimo/run-on-arch-action@v2.5.0
-      if: matrix.target != 'ppc64' && matrix.target != 'x86_64' && matrix.target != 'i686'
-      with:
-        arch: ${{ matrix.target }}
-        distro: ubuntu22.04
-        githubToken: ${{ github.token }}
-        install: |
-          apt-get update
-          apt-get install -y --no-install-recommends python3 python3-pip
-          pip3 install -U pip pytest
+      - name: Install built wheel (emulated)
+        uses: uraimo/run-on-arch-action@v2.5.0
+        if: matrix.target != 'ppc64' && matrix.target != 'x86_64' && matrix.target != 'i686'
+        with:
+          arch: ${{ matrix.target }}
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update
+            apt-get install -y --no-install-recommends python3 python3-pip
+            pip3 install -U pip pytest
+          run: |
+            pip install libs/gl-client-py/dist/gl_client*.whl --force-reinstall
+            python3 -c "import glclient;creds=glclient.Credentials();signer=glclient.Signer(b'\x00'*32,'bitcoin', creds);print(repr(creds));print(signer.version())"
+
+      - name: Install built wheel (native)
+        if: matrix.target == 'x86_64'
         run: |
           pip install libs/gl-client-py/dist/gl_client*.whl --force-reinstall
           python3 -c "import glclient;creds=glclient.Credentials();signer=glclient.Signer(b'\x00'*32,'bitcoin', creds);print(repr(creds));print(signer.version())"
 
-    - name: Install built wheel (native)
-      if: matrix.target == 'x86_64'
-      run: |
-          pip install libs/gl-client-py/dist/gl_client*.whl --force-reinstall
-          python3 -c "import glclient;creds=glclient.Credentials();signer=glclient.Signer(b'\x00'*32,'bitcoin', creds);print(repr(creds));print(signer.version())"
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: wheels
-        path: libs/gl-client-py/dist/
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: libs/gl-client-py/dist/
 
   macos:
     runs-on: macos-13
@@ -105,44 +105,43 @@ jobs:
       fail-fast: false
       matrix:
         target:
-        - x86_64
-        - aarch64
+          - x86_64
+          - aarch64
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-        architecture: x64
-    - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          architecture: x64
+      - uses: dtolnay/rust-toolchain@nightly
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v2
-      with:
-        version: "23.2"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build wheels - ${{ matrix.target }}
-      uses: PyO3/maturin-action@v1
-      with:
-        target: ${{ matrix.target }}
-        working-directory: libs/gl-client-py
-        args: --release --out dist
-        docker-options: -v /opt/hostedtoolcache/protoc/v23.2/x64/bin/protoc:/usr/bin/protoc:ro
-      env:
-        MACOSX_DEPLOYMENT_TARGET: 10.9
+      - name: Build wheels - ${{ matrix.target }}
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          working-directory: libs/gl-client-py
+          args: --release --out dist
+          docker-options: -v /opt/hostedtoolcache/protoc/v23.2/x64/bin/protoc:/usr/bin/protoc:ro
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.9
 
-    - name: Install built wheel
-      if: matrix.target == 'x86_64'
-      run: |
+      - name: Install built wheel
+        if: matrix.target == 'x86_64'
+        run: |
           pip install libs/gl-client-py/dist/gl_client*.whl --force-reinstall
           python3 -c "import glclient;creds=glclient.Credentials();signer=glclient.Signer(b'\x00'*32,'bitcoin', creds);print(repr(creds));print(signer.version())"
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: wheels
-        path: libs/gl-client-py/dist/
-
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: libs/gl-client-py/dist/
 
   windows:
     runs-on: windows-2019
@@ -153,36 +152,36 @@ jobs:
           - x64
           - x86
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-        architecture: ${{ matrix.target }}
-    - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          architecture: ${{ matrix.target }}
+      - uses: dtolnay/rust-toolchain@nightly
 
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v2
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build wheels
-      uses: PyO3/maturin-action@v1
-      with:
-        target: ${{ matrix.target }}
-        working-directory: libs\\gl-client-py
-        args: --release --out dist
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          working-directory: libs\\gl-client-py
+          args: --release --out dist
 
-# Wildcard expansion on windows is different...
-#    - name: Install built wheel
-#      run: |
-#          pip install libs\gl-client-py\dist\gl_client*.whl --force-reinstall
-#          python3 -c "import glclient;creds=glclient.Credentials();signer=glclient.Signer(b'\x00'*32,'bitcoin', creds);print(repr(creds));print(signer.version())"
+      # Wildcard expansion on windows is different...
+      #    - name: Install built wheel
+      #      run: |
+      #          pip install libs\gl-client-py\dist\gl_client*.whl --force-reinstall
+      #          python3 -c "import glclient;creds=glclient.Credentials();signer=glclient.Signer(b'\x00'*32,'bitcoin', creds);print(repr(creds));print(signer.version())"
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: wheels
-        path:  libs\gl-client-py\dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-win-${{ matrix.target }}
+          path: libs\gl-client-py\dist
 
   publish:
     runs-on: ubuntu-20.04
@@ -193,32 +192,32 @@ jobs:
       - macos
     if: github.ref == 'refs/heads/main'
     steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          path: libs/gl-client-py/dist
+          pattern: libs/gl-client-py/dist-*
+          merge-multiple: true
 
-    - name: Download wheels
-      uses: actions/download-artifact@v3
-      with:
-        name: wheels
-        path:  libs/gl-client-py/dist
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install python3-pip
+          sudo pip3 install -U \
+            poetry \
+            maturin \
+            twine \
+            keyring
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install python3-pip
-        sudo pip3 install -U \
-          poetry \
-          maturin \
-          twine \
-          keyring
-
-    - name: Publish wheels to PyPI
-      env:
-        TWINE_USERNAME: __token__
-      run: |
-        cd libs/gl-client-py
-        twine upload \
-          --skip-existing \
-          --non-interactive \
-          --verbose \
-          --username "__token__" \
-          --password "${{ secrets.TWINE_PASSWORD }}" \
-          dist/*.tar.gz dist/*.whl
+      - name: Publish wheels to PyPI
+        env:
+          TWINE_USERNAME: __token__
+        run: |
+          cd libs/gl-client-py
+          twine upload \
+            --skip-existing \
+            --non-interactive \
+            --verbose \
+            --username "__token__" \
+            --password "${{ secrets.TWINE_PASSWORD }}" \
+            dist/*.tar.gz dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ permissions:
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - "**[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
 
 jobs:
@@ -66,9 +66,9 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.runs-on }}
           path: dist-manifest.json
 
   # Build and packages all the platform-specific things
@@ -103,10 +103,10 @@ jobs:
         run: |
           brew install python@3.10
         if: ${{ runner.os == 'macOS' }}
-      - name: Install Protoc    
+      - name: Install Protoc
         uses: arduino/setup-protoc@v2
         with:
-          version: "23.2"  # Fixed since we mount the path below
+          version: "23.2" # Fixed since we mount the path below
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
         with:
@@ -140,9 +140,9 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.runs-on }}
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
@@ -168,10 +168,11 @@ jobs:
         with:
           submodules: recursive
       - name: "Download artifacts"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: artifacts
           path: artifacts
+          pattern: artifacts-*
+          merge-multiple: true
       - name: Cleanup
         run: |
           # Remove the granular manifests


### PR DESCRIPTION
> Artifact actions v3 will be closing down by January 30, 2025. You are receiving this email because you have GitHub Actions workflows using v3 of [actions/upload-artifact](https://app.github.media/e/er?s=88570519&lid=6648&elqTrackId=867ac6c9fa524bda9764f13bec8f8014&elq=cb3f66b75c2e4dffbd84b35f1097446c&elqaid=4286&elqat=1&elqak=8AF5D94B629B77D0B2E640E5D18BB16F1795B8B7563254EF101FA84EC79A1FE34BCA) or [actions/download-artifact](https://app.github.media/e/er?s=88570519&lid=6647&elqTrackId=bb54934dfd8c4c44b0e64ec2f2ba4824&elq=cb3f66b75c2e4dffbd84b35f1097446c&elqaid=4286&elqat=1&elqak=8AF57B355AADDDE608896B61A68B985ADA84B8B7563254EF101FA84EC79A1FE34BCA). After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.