### PR TITLE
tramp: remove waitsendpay timeout

### DIFF
--- a/libs/gl-plugin/src/tramp.rs
+++ b/libs/gl-plugin/src/tramp.rs
@@ -340,7 +340,7 @@ async fn do_pay(
     match rpc
         .call_typed(&cln_rpc::model::requests::WaitsendpayRequest {
             payment_hash: payment_hash,
-            timeout: Some(120),
+            timeout: None,
             partid: Some(part_id),
             groupid: Some(group_id),
         })


### PR DESCRIPTION
Remove the timeout on `waitsendpay` for trampoline. Payments may potentially take more than 2 minutes. The only reliable thing to do is wait until the payment parts come back. This could be aborted at any time by the greenlight node stopping or the client disconnecting. This brings `trampoline_pay` more in line with the behavior of `pay`, which will also wait indefinitely if a payment part is 'stuck' in the network.