### PR TITLE
signer: Increase the feerate for commitment TXs and warn on failure

### DIFF
--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -134,6 +134,16 @@ impl Signer {
             ],
         });
 
+        // TODO Remove this once VLS has implemented the fee budget
+        // per payment, rather than the fee budget per HTLC.
+        // Ref: https://github.com/Blockstream/greenlight/issues/538
+        {
+            policy.max_feerate_per_kw = 75_000;
+            policy.filter.merge(PolicyFilter {
+                rules: vec![FilterRule::new_warn("policy-commitment-fee-range")],
+            });
+        }
+
         policy.filter.merge(PolicyFilter {
             // TODO: Remove once we have implemented zero invoice support
             rules: vec![


### PR DESCRIPTION
This should get the couple of nodes that are stuck on a large
commitment TX fee unstuck. We triple the feerate in order to not run
into the deadlock, and we make the policy failure a warning instead.

This is not a solution to #538, since it is just a one-time adjustment. Ideally we'd have an independent feerate oracle that VLS can query independently.