### PR TITLE
ci: Fixes for failing workflows

### DIFF
--- a/.github/workflows/cln-version-manager-py.yml
+++ b/.github/workflows/cln-version-manager-py.yml
@@ -5,11 +5,11 @@ on:
     types:
       - synchronize
       - opened
-    workflow_dispatch:
-    merge_group:
-    push:
-      branches:
-        - master
+  workflow_dispatch:
+  merge_group:
+  push:
+    branches:
+      - master
 
 jobs:
   source:
@@ -41,18 +41,11 @@ jobs:
       - name: Install poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.2
       - name: Install dependencies
         run: poetry update && poetry install --no-interaction
       - name: Run mypy
         run: poetry run mypy
       - name: Run tests
         run: poetry run pytest tests
-
-    
-
-      
-    
-
-          
-        
-

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -44,9 +44,11 @@ RUN python3 -m venv /tmp/venv
 # This ensures poetry is always up-to-date.
 # This approach also ensures `poetry` and our environment don't overlap
 ENV POETRY_HOME=/tmp/poetry
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
 ENV PATH=$POETRY_HOME/bin:$PATH
-RUN poetry self add poetry-plugin-export
+
+# Uncomment below line after poetry v2.x.x upgrade
+# RUN poetry self add poetry-plugin-export
 
 # The pyproject.toml files describe our project
 # I purposefully ignore lock-files here
@@ -246,8 +248,10 @@ ENV VIRTUAL_ENV=/tmp/venv
 ARG GID=0
 ARG UID=0
 ARG DOCKER_USER=dev
-RUN groupadd -g $GID -o $DOCKER_USER &&\
-    useradd -m -u $UID -g $GID -G sudo -o -s /bin/bash $DOCKER_USER && \
+
+# Check if the group already exists before running groupadd
+RUN getent group $GID || groupadd -g $GID -o $DOCKER_USER && \
+    id -u $UID || useradd -m -u $UID -g $GID -G sudo -o -s /bin/bash $DOCKER_USER && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Create the required tmp-dicts


### PR DESCRIPTION
- Updated the `gl-testing` Dockerfile to use Poetry `1.8.2`, as Poetry `v2.x.x` installs the latest version of `pyln-grpc-proto` (`24.2.1`), which causes the `mypy glclient` check to fail. Poetry `1.8.2` installs `pyln-grpc-proto` version `0.1.3`, which works seamlessly with the CI.

- Added a check to ensure the group exists before adding it in the Docker.

- clnVersionManager: Locked Poetry version to `1.8.2` to allow for a coordinated upgrade in the future.