### PR TITLE
Rename crate `glcli` -> `gl-cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "gl-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dirs",
+ "env_logger 0.11.5",
+ "futures",
+ "gl-client",
+ "hex",
+ "thiserror 2.0.11",
+ "tokio 1.43.0",
+ "vls-core",
+]
+
+[[package]]
 name = "gl-client"
 version = "0.3.0"
 dependencies = [
@@ -1442,21 +1457,6 @@ dependencies = [
  "tonic-build 0.3.1",
  "tower 0.3.1",
  "which 4.4.2",
-]
-
-[[package]]
-name = "glcli"
-version = "0.1.0"
-dependencies = [
- "clap",
- "dirs",
- "env_logger 0.11.5",
- "futures",
- "gl-client",
- "hex",
- "thiserror 2.0.11",
- "tokio 1.43.0",
- "vls-core",
 ]
 
 [[package]]

--- a/libs/gl-cli/Cargo.toml
+++ b/libs/gl-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "glcli"
+name = "gl-cli"
 version = "0.1.0"
 edition = "2021"
 authors = ["Peter Neuroth <pet.v.ne@gmail.com>"]
@@ -11,6 +11,11 @@ keywords = ["lightning", "greenlight", "cli", "bitcoin", "blockchain"]
 categories = ["command-line-utlis", "cryptography::cryptocurrencies"]
 license = "MIT"
 reademe = "README.md"
+
+[[bin]]
+name = "glcli"
+test = true
+doc = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/libs/gl-cli/src/bin/glcli.rs
+++ b/libs/gl-cli/src/bin/glcli.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+use gl_cli::{run, Cli};
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+
+    match run(cli).await {
+        Ok(()) => (),
+        Err(e) => {
+            println!("{}", e);
+        }
+    }
+}

--- a/libs/gl-cli/src/lib.rs
+++ b/libs/gl-cli/src/lib.rs
@@ -37,18 +37,6 @@ pub enum Commands {
     Node(node::Command),
 }
 
-//#[tokio::main]
-//async fn main() {
-//    let cli = Cli::parse();
-//
-//    match run(cli).await {
-//        Ok(()) => (),
-//        Err(e) => {
-//            println!("{}", e);
-//        }
-//    }
-//}
-
 pub async fn run(cli: Cli) -> Result<()> {
     if cli.verbose {
         if std::env::var("RUST_LOG").is_err() {

--- a/libs/gl-cli/src/lib.rs
+++ b/libs/gl-cli/src/lib.rs
@@ -11,7 +11,7 @@ mod util;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-struct Cli {
+pub struct Cli {
     /// The directory containing the seed and the credentials
     #[arg(short, long, global = true, help_heading = "Global options")]
     data_dir: Option<String>,
@@ -25,7 +25,7 @@ struct Cli {
 }
 
 #[derive(Subcommand, Debug)]
-enum Commands {
+pub enum Commands {
     /// Interact with the scheduler that is the brain of most operations
     #[command(subcommand)]
     Scheduler(scheduler::Command),
@@ -37,19 +37,19 @@ enum Commands {
     Node(node::Command),
 }
 
-#[tokio::main]
-async fn main() {
-    let cli = Cli::parse();
+//#[tokio::main]
+//async fn main() {
+//    let cli = Cli::parse();
+//
+//    match run(cli).await {
+//        Ok(()) => (),
+//        Err(e) => {
+//            println!("{}", e);
+//        }
+//    }
+//}
 
-    match run(cli).await {
-        Ok(()) => (),
-        Err(e) => {
-            println!("{}", e);
-        }
-    }
-}
-
-async fn run(cli: Cli) -> Result<()> {
+pub async fn run(cli: Cli) -> Result<()> {
     if cli.verbose {
         if std::env::var("RUST_LOG").is_err() {
             std::env::set_var("RUST_LOG", "debug")


### PR DESCRIPTION
In ordert to stick to the naming scheme that has established around greenlight crates which is `gl-<package>`, this PR changes the name of the crate to be published to crates.io.
When using the binary, the newly introduced hyphen might be a bit cumbersome so we keep the name of the binary `glcli`.