### PR TITLE
Update `check` task

### DIFF
--- a/libs/cln-version-manager/.tasks.yml
+++ b/libs/cln-version-manager/.tasks.yml
@@ -3,8 +3,8 @@ version: '3'
 tasks:
   check:
     cmds:
-      - uv run --extra dev mypy clnvm
-      - uv run --extra dev pytest tests -vvv -s
+      - uv run --dev mypy clnvm
+      - uv run --dev pytest tests -vvv -s
 
   build:
     cmds:


### PR DESCRIPTION
CI was complaining about the usage of `--extra`, switch to `--dev` instead to include the `dev` dependency-group.