### PR TITLE
clnvm: Add v24.11gl1 and make it a bit more verbose

### DIFF
--- a/libs/cln-version-manager/clnvm/cli.py
+++ b/libs/cln-version-manager/clnvm/cli.py
@@ -14,13 +14,20 @@ def configure_logging() -> None:
         assert fname is not None, "logging.conf must be bundled as a resource"
         logging.config.fileConfig(fname)
 
+
 # Handle the optional import and provide a nice error message if it fails
 try:
     import click
+    from rich.logging import RichHandler
+    from rich.console import Console
+
+    logging.basicConfig(
+        level="NOTSET", format="%(message)s", datefmt="[%X]", handlers=[RichHandler(console=Console(stderr=True))]
+    )
 except Exception:
     print("To use clnvm the `cli` feature must be installed")
     print("You can install the feature using")
-    print("> pip install gltesting[cli]")
+    print("> pip install cln-version-manager[cli]")
     sys.exit(1)
 
 
@@ -36,6 +43,7 @@ def cli(verbose: bool) -> None:
 def get_all(force: bool) -> None:
     version_manager = ClnVersionManager()
     versions = version_manager.get_versions()
+    logging.info(f"Fetching {len(versions)} versions")
     for version in versions:
         try:
             result = version_manager.get(version, force)

--- a/libs/cln-version-manager/clnvm/cln_version_manager.py
+++ b/libs/cln-version-manager/clnvm/cln_version_manager.py
@@ -79,6 +79,11 @@ CLN_VERSIONS = [
         url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v24.02.tar.bz2",
         checksum="690f5b3ce0404504913bb7cde22d88efeabe72226aefe31a70916cf89905455d",
     ),
+    VersionDescriptor(
+        tag="v24.11gl1",
+        url="https://storage.googleapis.com/greenlight-artifacts/cln/lightningd-v24.11gl1.tar.bz2",
+        checksum="971ed2ea4e2c6a5efc6a68a338f0142ef47505a43e2b55bd5238b8afbf4cdb65",
+    ),
 ]
 
 

--- a/libs/cln-version-manager/clnvm/errors.py
+++ b/libs/cln-version-manager/clnvm/errors.py
@@ -43,7 +43,7 @@ class HashMismatch(Exception):
         self.expected = expected
 
     def __str__(self) -> str:
-        return f"The cryptographic hash of '{self.tag}' doesn't match."
+        return self.__repr__()
 
     def __repr__(self) -> str:
         return f"HashMismatch(tag={self.tag}, actual={self.actual}, expected={self.expected})"

--- a/libs/cln-version-manager/pyproject.toml
+++ b/libs/cln-version-manager/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = [
     "requests>=2.32.3",
 ]
 
+[project.optional-dependencies]
+cli = [
+    "click",
+    "rich",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
The `clnvm` tool was way too quiet for my liking, so I added logging to `stderr` not to interfere with tooling that may already rely on the tool printing the paths of versions to `stdout`.

I then also added the new version to deploy in `prod`.