### PR TITLE
signer: Add CLN v24.11 to supported versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.10.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
 name = "bip39"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,12 +405,27 @@ version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
  "bitcoinconsensus",
  "hex_lit",
  "secp256k1 0.27.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
+dependencies = [
+ "bech32 0.10.0-beta",
+ "bitcoin-internals",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1 0.28.2",
  "serde",
 ]
 
@@ -420,6 +441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,7 +461,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee01fc59f06261a3727830dc61fd87f9f9ae503194d7aea0306a2535a9a06a3d"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.2",
  "hex",
  "log",
 ]
@@ -449,6 +479,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
  "serde",
 ]
 
@@ -679,19 +720,23 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc"
-version = "0.1.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b7b9e8de980dba797a0885b99fda797638d8a207089cb98710d94285e871df"
+checksum = "1f3a50be955808d07d6f33f05bb11ce5a3875d92b4d1fff5623f9458feb5164c"
 dependencies = [
  "anyhow",
- "bitcoin",
+ "bitcoin 0.31.2",
  "cln-rpc",
+ "futures-core",
  "hex",
  "log",
- "prost 0.11.9",
+ "prost 0.12.6",
  "serde",
- "tonic 0.8.3",
- "tonic-build 0.8.4",
+ "tokio 1.43.0",
+ "tokio-stream",
+ "tokio-util 0.7.11",
+ "tonic 0.11.0",
+ "tonic-build 0.11.0",
 ]
 
 [[package]]
@@ -715,12 +760,12 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.1.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2653217d27aee65a670f0c4f340b8f70b1f0b4e1c2fa085afe1b8e24ba12c069"
+checksum = "f4436e58f1fccb1faf69df9ac436ae9304b5c200c7d92e6c4229826bdd0a8d0d"
 dependencies = [
  "anyhow",
- "bitcoin",
+ "bitcoin 0.31.2",
  "bytes 1.6.0",
  "futures-util",
  "hex",
@@ -1321,7 +1366,7 @@ dependencies = [
  "async-stream 0.3.5",
  "async-trait",
  "base64 0.21.7",
- "bech32",
+ "bech32 0.9.1",
  "bytes 1.6.0",
  "chacha20poly1305",
  "chrono",
@@ -1336,14 +1381,14 @@ dependencies = [
  "picky-asn1-der 0.4.1",
  "picky-asn1-x509 0.12.0",
  "pin-project 1.1.5",
- "prost 0.11.9",
- "prost-derive 0.11.9",
+ "prost 0.12.6",
+ "prost-derive 0.12.6",
  "rand 0.8.5",
  "rcgen",
  "reqwest",
  "ring 0.16.20",
  "runeauth",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "secp256k1 0.26.0",
  "serde",
  "serde_json",
@@ -1353,8 +1398,8 @@ dependencies = [
  "time",
  "tokio 1.43.0",
  "tokio-stream",
- "tonic 0.8.3",
- "tonic-build 0.8.4",
+ "tonic 0.11.0",
+ "tonic-build 0.11.0",
  "tower 0.4.13",
  "url",
  "uuid",
@@ -1376,13 +1421,13 @@ dependencies = [
  "hex",
  "log",
  "once_cell",
- "prost 0.11.9",
+ "prost 0.12.6",
  "pyo3",
  "runeauth",
  "serde_json",
  "thiserror 1.0.61",
  "tokio 1.43.0",
- "tonic 0.8.3",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -1420,7 +1465,7 @@ dependencies = [
  "linemux",
  "log",
  "nix",
- "prost 0.11.9",
+ "prost 0.12.6",
  "serde",
  "serde_json",
  "sled",
@@ -1428,8 +1473,8 @@ dependencies = [
  "tokio 1.43.0",
  "tokio-stream",
  "tokio-util 0.7.11",
- "tonic 0.8.3",
- "tonic-build 0.8.4",
+ "tonic 0.11.0",
+ "tonic-build 0.11.0",
  "tower 0.4.13",
  "vls-protocol",
 ]
@@ -1534,12 +1579,6 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1978,7 +2017,7 @@ version = "0.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd92d4aa159374be430c7590e169b4a6c0fb79018f5bc4ea1bffde536384db3"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.2",
  "hex-conservative",
  "regex",
 ]
@@ -1989,8 +2028,8 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d07d01cf197bf2184b929b7dc94aa70d935aac6df896c256a3a9475b7e9d40"
 dependencies = [
- "bech32",
- "bitcoin",
+ "bech32 0.9.1",
+ "bitcoin 0.30.2",
  "lightning",
  "secp256k1 0.27.0",
 ]
@@ -2733,12 +2772,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2762,12 +2801,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes 1.6.0",
- "prost-derive 0.11.9",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -2790,24 +2829,23 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.6.0",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.10.5",
- "lazy_static",
  "log",
  "multimap",
+ "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
- "prost 0.11.9",
- "prost-types 0.11.9",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.96",
  "tempfile",
- "which 4.4.2",
 ]
 
 [[package]]
@@ -2825,15 +2863,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2848,11 +2886,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.11.9",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -3132,7 +3170,7 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "rustls 0.21.12",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3252,19 +3290,7 @@ dependencies = [
  "log",
  "ring 0.16.20",
  "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring 0.16.20",
- "sct 0.7.1",
- "webpki 0.22.4",
+ "webpki",
 ]
 
 [[package]]
@@ -3275,8 +3301,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct 0.7.1",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3286,7 +3326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -3301,12 +3341,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -3372,7 +3438,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
 ]
 
 [[package]]
@@ -3383,7 +3449,18 @@ checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes 0.12.0",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "secp256k1-sys 0.9.2",
  "serde",
 ]
 
@@ -3392,6 +3469,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -3434,7 +3520,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffab210d8357b433ffab5b3fd39d56f7fddb5eb36c84039fa455933ef05209f"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.2",
  "bitcoin-consensus-derive",
  "chunked-buffer",
  "hex",
@@ -3971,18 +4057,7 @@ dependencies = [
  "futures-core",
  "rustls 0.18.1",
  "tokio 0.2.25",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio 1.43.0",
- "webpki 0.22.4",
+ "webpki",
 ]
 
 [[package]]
@@ -3996,6 +4071,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio 1.43.0",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,6 +4090,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.14",
  "tokio 1.43.0",
+ "tokio-util 0.7.11",
 ]
 
 [[package]]
@@ -4066,17 +4153,15 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream 0.3.5",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.7",
  "bytes 1.6.0",
- "futures-core",
- "futures-util",
  "h2 0.3.26",
  "http",
  "http-body 0.4.6",
@@ -4084,18 +4169,16 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.5",
- "prost 0.11.9",
- "prost-derive 0.11.9",
- "rustls-pemfile",
+ "prost 0.12.6",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "tokio 1.43.0",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
- "tokio-util 0.7.11",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -4112,15 +4195,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.11.9",
+ "prost-build 0.12.6",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4405,7 +4488,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5675f1c4ed9845d91baa88cc10aff641867ed17b32440f9e26cd04c086610ba0"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.2",
  "log",
  "serde",
  "serde_bolt",
@@ -4544,7 +4627,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "backtrace",
- "bitcoin",
+ "bitcoin 0.30.2",
  "bitcoin-consensus-derive",
  "bitcoin-push-decoder",
  "bolt-derive",
@@ -4736,16 +4819,6 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring 0.16.20",
  "untrusted 0.7.1",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -370,12 +376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "bech32"
-version = "0.10.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
-
-[[package]]
 name = "bip39"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,29 +395,16 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.29.2"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
 dependencies = [
- "bech32 0.9.1",
- "bitcoin_hashes 0.11.0",
+ "bech32",
+ "bitcoin-private",
+ "bitcoin_hashes 0.12.0",
  "bitcoinconsensus",
- "secp256k1 0.24.3",
- "serde",
-]
-
-[[package]]
-name = "bitcoin"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
-dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
- "hex-conservative",
  "hex_lit",
- "secp256k1 0.28.2",
+ "secp256k1 0.27.0",
  "serde",
 ]
 
@@ -433,15 +420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,11 +427,12 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin-push-decoder"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d533f86c679e4388a80f0c11524ae690dc1850315007757dced23ecd53526bbe"
+checksum = "ee01fc59f06261a3727830dc61fd87f9f9ae503194d7aea0306a2535a9a06a3d"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin",
+ "hex",
  "log",
 ]
 
@@ -462,9 +441,6 @@ name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -473,16 +449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals",
- "hex-conservative",
  "serde",
 ]
 
@@ -713,23 +679,19 @@ dependencies = [
 
 [[package]]
 name = "cln-grpc"
-version = "0.4.0"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3a50be955808d07d6f33f05bb11ce5a3875d92b4d1fff5623f9458feb5164c"
+checksum = "85b7b9e8de980dba797a0885b99fda797638d8a207089cb98710d94285e871df"
 dependencies = [
  "anyhow",
- "bitcoin 0.31.2",
+ "bitcoin",
  "cln-rpc",
- "futures-core",
  "hex",
  "log",
- "prost 0.12.6",
+ "prost 0.11.9",
  "serde",
- "tokio 1.43.0",
- "tokio-stream",
- "tokio-util 0.7.11",
- "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic 0.8.3",
+ "tonic-build 0.8.4",
 ]
 
 [[package]]
@@ -753,12 +715,12 @@ dependencies = [
 
 [[package]]
 name = "cln-rpc"
-version = "0.4.0"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4436e58f1fccb1faf69df9ac436ae9304b5c200c7d92e6c4229826bdd0a8d0d"
+checksum = "2653217d27aee65a670f0c4f340b8f70b1f0b4e1c2fa085afe1b8e24ba12c069"
 dependencies = [
  "anyhow",
- "bitcoin 0.31.2",
+ "bitcoin",
  "bytes 1.6.0",
  "futures-util",
  "hex",
@@ -1359,7 +1321,7 @@ dependencies = [
  "async-stream 0.3.5",
  "async-trait",
  "base64 0.21.7",
- "bech32 0.9.1",
+ "bech32",
  "bytes 1.6.0",
  "chacha20poly1305",
  "chrono",
@@ -1374,14 +1336,14 @@ dependencies = [
  "picky-asn1-der 0.4.1",
  "picky-asn1-x509 0.12.0",
  "pin-project 1.1.5",
- "prost 0.12.6",
- "prost-derive 0.12.6",
+ "prost 0.11.9",
+ "prost-derive 0.11.9",
  "rand 0.8.5",
  "rcgen",
  "reqwest",
  "ring 0.16.20",
  "runeauth",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "secp256k1 0.26.0",
  "serde",
  "serde_json",
@@ -1391,8 +1353,8 @@ dependencies = [
  "time",
  "tokio 1.43.0",
  "tokio-stream",
- "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic 0.8.3",
+ "tonic-build 0.8.4",
  "tower 0.4.13",
  "url",
  "uuid",
@@ -1414,13 +1376,13 @@ dependencies = [
  "hex",
  "log",
  "once_cell",
- "prost 0.12.6",
+ "prost 0.11.9",
  "pyo3",
  "runeauth",
  "serde_json",
  "thiserror 1.0.61",
  "tokio 1.43.0",
- "tonic 0.11.0",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -1458,7 +1420,7 @@ dependencies = [
  "linemux",
  "log",
  "nix",
- "prost 0.12.6",
+ "prost 0.11.9",
  "serde",
  "serde_json",
  "sled",
@@ -1466,8 +1428,8 @@ dependencies = [
  "tokio 1.43.0",
  "tokio-stream",
  "tokio-util 0.7.11",
- "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic 0.8.3",
+ "tonic-build 0.8.4",
  "tower 0.4.13",
  "vls-protocol",
 ]
@@ -1545,19 +1507,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
-dependencies = [
- "ahash",
- "autocfg",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1573,6 +1534,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2007,27 +1974,25 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.118"
+version = "0.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cec5fa9382154fe9671e8df93095b800c7d77abc66e2a5ef839d672521c5e"
+checksum = "5fd92d4aa159374be430c7590e169b4a6c0fb79018f5bc4ea1bffde536384db3"
 dependencies = [
- "bitcoin 0.29.2",
- "hex",
+ "bitcoin",
+ "hex-conservative",
  "regex",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.26.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb24878b0f4ef75f020976c886d9ad1503867802329cc963e0ab4623ea3b25c"
+checksum = "26d07d01cf197bf2184b929b7dc94aa70d935aac6df896c256a3a9475b7e9d40"
 dependencies = [
- "bech32 0.9.1",
- "bitcoin 0.29.2",
- "bitcoin_hashes 0.11.0",
+ "bech32",
+ "bitcoin",
  "lightning",
- "num-traits",
- "secp256k1 0.24.3",
+ "secp256k1 0.27.0",
 ]
 
 [[package]]
@@ -2768,12 +2733,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2797,12 +2762,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes 1.6.0",
- "prost-derive 0.12.6",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -2825,23 +2790,24 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes 1.6.0",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.10.5",
+ "lazy_static",
  "log",
  "multimap",
- "once_cell",
  "petgraph 0.6.5",
  "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
- "syn 2.0.96",
+ "syn 1.0.109",
  "tempfile",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -2859,15 +2825,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2882,11 +2848,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost 0.12.6",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -3166,7 +3132,7 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "rustls 0.21.12",
  "rustls-native-certs",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3286,7 +3252,19 @@ dependencies = [
  "log",
  "ring 0.16.20",
  "sct 0.6.1",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct 0.7.1",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -3297,22 +3275,8 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki 0.101.7",
+ "rustls-webpki",
  "sct 0.7.1",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3322,7 +3286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -3337,38 +3301,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring 0.17.8",
- "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -3430,43 +3368,23 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "bitcoin_hashes 0.11.0",
- "rand 0.8.5",
- "secp256k1-sys 0.6.1",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys 0.8.1",
+ "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes 0.12.0",
- "secp256k1-sys 0.9.2",
+ "rand 0.8.5",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3474,15 +3392,6 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -3521,11 +3430,11 @@ dependencies = [
 
 [[package]]
 name = "serde_bolt"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06b8577e0fd88c67c88e08139a7ecb7b6ab9b8800dfe1290d3de66d2a2601f2"
+checksum = "bffab210d8357b433ffab5b3fd39d56f7fddb5eb36c84039fa455933ef05209f"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin",
  "bitcoin-consensus-derive",
  "chunked-buffer",
  "hex",
@@ -4062,7 +3971,18 @@ dependencies = [
  "futures-core",
  "rustls 0.18.1",
  "tokio 0.2.25",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio 1.43.0",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -4076,17 +3996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio 1.43.0",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,7 +4004,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.14",
  "tokio 1.43.0",
- "tokio-util 0.7.11",
 ]
 
 [[package]]
@@ -4158,15 +4066,17 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream 0.3.5",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.13.1",
  "bytes 1.6.0",
+ "futures-core",
+ "futures-util",
  "h2 0.3.26",
  "http",
  "http-body 0.4.6",
@@ -4174,16 +4084,18 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.1.5",
- "prost 0.12.6",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
+ "prost 0.11.9",
+ "prost-derive 0.11.9",
+ "rustls-pemfile",
  "tokio 1.43.0",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
+ "tokio-util 0.7.11",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -4200,15 +4112,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.11.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
+ "prost-build 0.11.9",
  "quote",
- "syn 2.0.96",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4489,11 +4401,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "txoo"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9db6dd6fd9fff3c0d875c1d8b891481c368b02c76d81bacd0f52f832a3699ef"
+checksum = "5675f1c4ed9845d91baa88cc10aff641867ed17b32440f9e26cd04c086610ba0"
 dependencies = [
- "bitcoin 0.29.2",
+ "bitcoin",
  "log",
  "serde",
  "serde_bolt",
@@ -4615,19 +4527,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "vls-core"
-version = "0.12.0"
+name = "vls-common"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4ffd7d4f73477364006d79e58f7a78e2abf7db1bd715ca285f4dfc897f5a44"
+checksum = "3b78705ec28a9904243cc3a7117840a8153166561288076fc5a9aa2ea89811f8"
 dependencies = [
+ "hex",
+]
+
+[[package]]
+name = "vls-core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be3166ccaea17097c368ab83692116ac136894d2e514876fb31609f63fc2e928"
+dependencies = [
+ "ahash",
  "anyhow",
  "backtrace",
- "bitcoin 0.29.2",
+ "bitcoin",
  "bitcoin-consensus-derive",
  "bitcoin-push-decoder",
  "bolt-derive",
  "env_logger 0.9.3",
- "hashbrown 0.8.2",
+ "hashbrown 0.13.2",
  "hex",
  "itertools 0.10.5",
  "lightning",
@@ -4640,13 +4562,15 @@ dependencies = [
  "serde_with",
  "tracing",
  "txoo",
+ "vls-common",
+ "vls-policy-derive",
 ]
 
 [[package]]
 name = "vls-persist"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1908e667de1b883705b13d6247a1ac276bedf033f08ce0193a1d7313e25b4f"
+checksum = "3da49b2af05d819f7f42278b78d4c165ec003474f7a5fd8c1f282183b10d311f"
 dependencies = [
  "hex",
  "log",
@@ -4659,10 +4583,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "vls-protocol"
-version = "0.12.0"
+name = "vls-policy-derive"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a587cd1c110fcb5b3ba1ce043f94040c2fd704a05bd4f6aa5d8b9b9bdaaa8b"
+checksum = "98b17d0402fe542a86bcac5a2b52a78448a38d13bb6a133a67a8143c6eaad608"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "vls-protocol"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8597fe72d5490db26270939d50adeed16baf7be57522e6ebaa8f3a760f28ae7b"
 dependencies = [
  "as-any",
  "bitcoin-consensus-derive",
@@ -4676,9 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "vls-protocol-signer"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83515109f514a78497cc13fc81ffc7cc3ff6ef46b623e6a710bc56b60a02b8e"
+checksum = "00ed706a354b586f1339de6828ef8635c132461ea7dff4da2c8f80bcc00c3a0a"
 dependencies = [
  "bit-vec",
  "log",
@@ -4801,6 +4736,16 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring 0.16.20",
  "untrusted 0.7.1",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5089,6 +5034,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ cln-grpc = "0.4"
 cln-rpc = "0.4"
 cln-plugin = "0.4"
 
-vls-core = "^0.12"
-vls-persist = "^0.12"
-vls-protocol-signer = "^0.12"
-vls-protocol = "^0.12"
+vls-core = "^0.13"
+vls-persist = "^0.13"
+vls-protocol-signer = "^0.13"
+vls-protocol = "^0.13"
 
 
 # Config for 'cargo dist'

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ CLN_VERSIONS = \
 	v22.11gl1 \
 	v23.05gl1 \
 	v23.08gl1 \
-	v24.02gl1
+	v24.02gl1 \
+	v24.11gl1
 
 DOCKER_OPTIONS= \
 	--rm \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,7 +34,7 @@ tasks:
       - task: testing:check
       - task: clnvm:check
 
-  docker-ci-check:
+  docker-ci-build:
     cmds:
       - >
         docker buildx build \
@@ -47,9 +47,19 @@ tasks:
           -t gltesting \
           -f docker/gl-testing/Dockerfile \
           .
-      - docker run -ti -v $(pwd):/repo gltesting task ci-check
+    
+  docker-ci-check:
+    deps:
+#      - docker-ci-build
+    cmds:
+      - docker run --rm -ti -v $(pwd):/repo gltesting task ci-check
 
   ci-build:
     cmds:
       - task: signerproxy:build
       - task: plugin:build
+  clean:
+    dir: "."
+    cmds:
+      - cargo clean
+      - rm -rf .venv

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -175,7 +175,6 @@ ENV GRPC_ENABLE_FORK_SUPPORT=0
 
 # Install cln-versions
 ENV CLNVM_CACHE_DIR=/opt/cln
-ENV GL_TESTING_IGNORE_HASH=1
 
 # Enumerate all versions that gl-testing should find
 ENV CLN_PATH=/opt/cln/v0.10.1/usr/local/bin/:/opt/cln/v0.10.2/usr/local/bin/:/opt/cln/v0.11.0.1/usr/local/bin/:/opt/cln/v0.11.2gl2/usr/local/bin/:/opt/cln/v22.11gl1/usr/local/bin/:/opt/cln/v23.05gl1/usr/local/bin/:/opt/cln/v23.08gl1/usr/local/bin/:/opt/cln/v24.02gl1/usr/local/bin/:/opt/cln/v24.11gl1/usr/local/bin/

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -178,7 +178,7 @@ ENV CLNVM_CACHE_DIR=/opt/cln
 ENV GL_TESTING_IGNORE_HASH=1
 
 # Enumerate all versions that gl-testing should find
-ENV CLN_PATH=/opt/cln/v0.10.1/usr/local/bin/:/opt/cln/v0.10.2/usr/local/bin/:/opt/cln/v0.11.0.1/usr/local/bin/:/opt/cln/v0.11.2gl2/usr/local/bin/:/opt/cln/v22.11gl1/usr/local/bin/:/opt/cln/v23.05gl1/usr/local/bin/:/opt/cln/v23.08gl1/usr/local/bin/:/opt/cln/v24.02gl1/usr/local/bin/
+ENV CLN_PATH=/opt/cln/v0.10.1/usr/local/bin/:/opt/cln/v0.10.2/usr/local/bin/:/opt/cln/v0.11.0.1/usr/local/bin/:/opt/cln/v0.11.2gl2/usr/local/bin/:/opt/cln/v22.11gl1/usr/local/bin/:/opt/cln/v23.05gl1/usr/local/bin/:/opt/cln/v23.08gl1/usr/local/bin/:/opt/cln/v24.02gl1/usr/local/bin/:/opt/cln/v24.11gl1/usr/local/bin/
 
 # Create a non-root user.
 ARG GID=0

--- a/libs/gl-client-py/.tasks.yml
+++ b/libs/gl-client-py/.tasks.yml
@@ -1,9 +1,17 @@
 version: '3'
 
 tasks:
+  force-install:
+    dir: "."
+    cmds:
+      # Forces a reinstall of the latest version
+      - uv run maturin develop  
+  
   check:
     env:
       PYTEST_OPTS: "-vvv"
+    deps:
+      - force-install
     cmds:
       - uv run pytest tests $PYTEST_OPTS
 

--- a/libs/gl-client-py/glclient/__init__.py
+++ b/libs/gl-client-py/glclient/__init__.py
@@ -17,7 +17,7 @@ backup_decrypt_with_seed = native.backup_decrypt_with_seed
 
 
 # Keep in sync with the libhsmd version, this is tested in unit tests.
-__version__ = "v24.02"
+__version__ = "v24.11"
 
 
 E = TypeVar("E", bound=PbMessage)

--- a/libs/gl-client-py/pyproject.toml
+++ b/libs/gl-client-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gl-client"
-version = "0.3.2"
+version = "0.3.2rc1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/libs/gl-client-py/pyproject.toml
+++ b/libs/gl-client-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gl-client"
-version = "0.3.1"
+version = "0.3.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/libs/gl-client-py/pyproject.toml
+++ b/libs/gl-client-py/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "grpcio>=1.67",
     "maturin>=1",
     "mypy>=1.14.1",
+    "patchelf>=0.17.2.2",
     "protobuf>=4",
     "pyln-grpc-proto>=0.1.2",
     "types-protobuf>=5.29.1.20241207",

--- a/libs/gl-client/src/lnurl/pay/mod.rs
+++ b/libs/gl-client/src/lnurl/pay/mod.rs
@@ -108,7 +108,7 @@ pub fn validate_invoice_from_callback_response(
     );
 
     let description_hash: String = match invoice.description() {
-        Bolt11InvoiceDescription::Direct(d) => sha256::digest(d.clone().into_inner()),
+        Bolt11InvoiceDescription::Direct(d) => sha256::digest(d.to_string()),
         Bolt11InvoiceDescription::Hash(h) => h.0.to_string(),
     };
 

--- a/libs/gl-client/src/persist.rs
+++ b/libs/gl-client/src/persist.rs
@@ -512,6 +512,9 @@ impl Persist for MemoryPersister {
                 0,
                 state_e.velocity_control.into(),
                 state_e.fee_velocity_control.into(),
+                0u64,
+                /* dbid_high_water_mark: prevents reuse of
+                 * channel dbid, 0 disables enforcement. */
             );
 
             let entry = lightning_signer::persist::model::NodeEntry {

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -47,7 +47,7 @@ pub mod model;
 mod report;
 mod resolve;
 
-const VERSION: &str = "v24.02";
+const VERSION: &str = "v24.11";
 const GITHASH: &str = env!("GIT_HASH");
 const RUNE_VERSION: &str = "gl0";
 // This is the same derivation key that is used by core lightning itself.

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -122,7 +122,8 @@ impl Signer {
         // The persister takes care of persisting metadata across
         // restarts
         let persister = Arc::new(crate::persist::MemoryPersister::new());
-        let mut policy = lightning_signer::policy::simple_validator::make_simple_policy(network);
+        let mut policy =
+            lightning_signer::policy::simple_validator::make_default_simple_policy(network);
 
         policy.filter = PolicyFilter::default();
         policy.filter.merge(PolicyFilter {
@@ -141,9 +142,9 @@ impl Signer {
             policy.max_feerate_per_kw = 150_000;
             policy.filter.merge(PolicyFilter {
                 rules: vec![
-		    FilterRule::new_warn("policy-commitment-fee-range"),
-		    FilterRule::new_warn("policy-mutual-fee-range"),
-		],
+                    FilterRule::new_warn("policy-commitment-fee-range"),
+                    FilterRule::new_warn("policy-mutual-fee-range"),
+                ],
             });
         }
 

--- a/libs/gl-client/src/signer/mod.rs
+++ b/libs/gl-client/src/signer/mod.rs
@@ -270,26 +270,8 @@ impl Signer {
             dev_bip32_seed: None,
             dev_channel_secrets: None,
             dev_channel_secrets_shaseed: None,
-            hsm_wire_min_version: 5,
-            hsm_wire_max_version: 5,
-        })
-    }
-
-    fn bolt12initreq() -> vls_protocol::msgs::Message {
-        vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
-            info: Octets("bolt12-invoice-base".as_bytes().to_vec()),
-        })
-    }
-
-    fn scbinitreq() -> vls_protocol::msgs::Message {
-        vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
-            info: Octets("scb secret".as_bytes().to_vec()),
-        })
-    }
-
-    fn commandoinitreq() -> vls_protocol::msgs::Message {
-        vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
-            info: Octets("commando".as_bytes().to_vec()),
+            hsm_wire_min_version: 4,
+            hsm_wire_max_version: 6,
         })
     }
 
@@ -642,11 +624,24 @@ impl Signer {
         let requests = vec![
             // v22.11 introduced an addiotiona startup message, the
             // bolt12 key generation
-            Signer::bolt12initreq(),
+            vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
+                info: Octets("bolt12-invoice-base".as_bytes().to_vec()),
+            }),
             // SCB needs a secret derived too
-            Signer::scbinitreq(),
+            vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
+                info: Octets("scb secret".as_bytes().to_vec()),
+            }),
             // Commando needs a secret for its runes
-            Signer::commandoinitreq(),
+            vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
+                info: Octets("commando".as_bytes().to_vec()),
+            }),
+            // The node alias key
+            vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
+                info: Octets("node-alias-base".as_bytes().to_vec()),
+            }),
+            vls_protocol::msgs::Message::DeriveSecret(vls_protocol::msgs::DeriveSecret {
+                info: Octets("offer-blinded-path".as_bytes().to_vec()),
+            }),
         ];
 
         let serialized: Vec<Vec<u8>> = requests.iter().map(|m| m.inner().as_vec()).collect();

--- a/libs/gl-client/src/signer/resolve.rs
+++ b/libs/gl-client/src/signer/resolve.rs
@@ -77,7 +77,7 @@ impl Resolver {
                 }
                 (Message::NewChannel(m1), Request::FundChannel(m2)) => {
                     // Different node_id? Reject!
-                    m1.node_id.0 == m2.id.as_slice()
+                    m1.peer_id.0 == m2.id.as_slice()
                     // TODO: Add `close_to` to allowlist for the close
                     // later on
                 }

--- a/libs/gl-testing/gltesting/node.py
+++ b/libs/gl-testing/gltesting/node.py
@@ -92,11 +92,11 @@ class NodeProcess(TailableProc):
             '--disable-plugin=cln-grpc',
             f'--subdaemon=hsmd:{signerproxy_path}',
             f'--important-plugin={plugin_path}',
-            '--dev-bitcoind-poll=5',
-            '--dev-fast-gossip',
+            #'--dev-bitcoind-poll=5',
+            #'--dev-fast-gossip',
             '--offline',
-            '--experimental-anchors',
-            '--developer',  # TODO Make this multi-version capable
+            #'--experimental-anchors',
+            #'--developer',  # TODO Make this multi-version capable
         ]
 
     def write_node_config(self, network: str):

--- a/libs/gl-testing/gltesting/node.py
+++ b/libs/gl-testing/gltesting/node.py
@@ -92,11 +92,11 @@ class NodeProcess(TailableProc):
             '--disable-plugin=cln-grpc',
             f'--subdaemon=hsmd:{signerproxy_path}',
             f'--important-plugin={plugin_path}',
-            #'--dev-bitcoind-poll=5',
-            #'--dev-fast-gossip',
+            '--dev-bitcoind-poll=5',
+            '--dev-fast-gossip',
             '--offline',
             #'--experimental-anchors',
-            #'--developer',  # TODO Make this multi-version capable
+            '--developer',  # TODO Make this multi-version capable
         ]
 
     def write_node_config(self, network: str):

--- a/libs/gl-testing/gltesting/node.py
+++ b/libs/gl-testing/gltesting/node.py
@@ -95,6 +95,7 @@ class NodeProcess(TailableProc):
             '--dev-bitcoind-poll=5',
             '--dev-fast-gossip',
             '--offline',
+            '--allow-deprecated-apis=true',
             #'--experimental-anchors',
             '--developer',  # TODO Make this multi-version capable
         ]

--- a/libs/gl-testing/gltesting/utils.py
+++ b/libs/gl-testing/gltesting/utils.py
@@ -19,6 +19,7 @@ class SignerVersion:
             "v23.05": ["v23.05gl1"],
             "v23.08": ["v23.08gl1"],
             "v24.02": ["v24.02gl1"],
+            "v24.11": ["v24.11gl1"],
         }
 
         return self.name in compat[nv.name]
@@ -35,6 +36,7 @@ class SignerVersion:
             "v23.05": "v23.05gl1",
             "v23.08": "v23.08gl1",
             "v24.02": "v24.02gl1",
+            "v24.11": "v24.11gl1",
         }
         return m[self.name]
 

--- a/libs/gl-testing/pyproject.toml
+++ b/libs/gl-testing/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "gl-client",
     "grpcio-tools>=1.66",
     "grpcio>=1.66.0",
-    "httpx[http2]==0.27.2",
+    "httpx[http2]>=0.28",
     "purerpc>=0.8.0",
     "pyln-client==24.2",
     "pyln-testing==24.2",

--- a/libs/gl-testing/pyproject.toml
+++ b/libs/gl-testing/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "gl-client",
     "grpcio-tools>=1.66",
     "grpcio>=1.66.0",
-    "httpx[http2]>=0.28",
+    "httpx[http2]==0.27.2",
     "purerpc>=0.8.0",
     "pyln-client==24.2",
     "pyln-testing==24.2",

--- a/libs/gl-testing/tests/test_grpc_web.py
+++ b/libs/gl-testing/tests/test_grpc_web.py
@@ -47,7 +47,7 @@ def test_node_grpc_web(scheduler, node_grpc_web_proxy, clients):
     c = clients.new()
     c.register(configure=True)
     n = c.node()
-    _s =    c.signer().run_in_thread()
+    _s = c.signer().run_in_thread()
     info = n.get_info()
 
     # Now extract the TLS certificates, so we can sign the payload.

--- a/libs/gl-testing/tests/test_node.py
+++ b/libs/gl-testing/tests/test_node.py
@@ -455,7 +455,7 @@ def test_vls_crash_repro(
 ) -> None:
     """Reproduce an overflow panic in VLS v0.10.0."""
     (l1,) = node_factory.line_graph(1, opts={"experimental-anchors": None})
-    assert l1.rpc.getinfo()["version"] == "v24.02gl1"
+    assert l1.rpc.getinfo()["version"] == "v24.11gl1"
 
     c = clients.new()
     c.register(configure=True)


### PR DESCRIPTION
This PR adds support for CLN v24.11. It'll trigger an upgrade on the
node as soon as it connects the first time, and will act as its signer
from thereon.

We're keeping it a draft, while we verify the core functionality, and
will merge as soon as it is deemed stable. Feel free to use this
signer version, however be aware that there is currently no way to
downgrade once upgraded, so use test nodes.