### PR TITLE
Refine ARM64 multi-arch Docker builds and dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ gen: ${GENALL}
 
 build-self: ensure-docker
 	cargo build --all
-	uv sync --package gl-client --extra dev
+	uv sync --package gl-client --group dev
 
 check-all: check-rs check-self check-py check-testing-py
 

--- a/docker/gl-testing/Dockerfile
+++ b/docker/gl-testing/Dockerfile
@@ -83,11 +83,18 @@ RUN chmod a+rwx -R $CARGO_HOME
 # Downloads bitcoin-core
 FROM ubuntu:22.04 AS bitcoin-downloader
 RUN apt update && apt install -qqy wget
+ARG TARGETPLATFORM
 
 ARG BITCOIN_VERSION=25.0
 
-RUN cd /tmp/ && \
-    wget "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz" -O bitcoin.tar.gz && \
+RUN PLATFORM=$( \
+    case ${TARGETPLATFORM} in \
+    linux/amd64 ) echo "x86_64";; \
+    linux/arm64 ) echo "aarch64";; \
+    esac \
+    ) && \
+    cd /tmp/ && \
+    wget "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${PLATFORM}-linux-gnu.tar.gz" -O bitcoin.tar.gz && \
     tar -xvzf bitcoin.tar.gz && \
     mv /tmp/bitcoin-$BITCOIN_VERSION/ /opt/bitcoin && \
     rm -rf bitcoin.tar.gz /tmp/bitcoin-$BITCOIN_VERSION
@@ -97,12 +104,13 @@ RUN cd /tmp/ && \
 # --------------------------------------
 # Downloads cloudlfares SSL binaries
 FROM ubuntu:22.04 AS cfssl-downloader
+ARG TARGETARCH
 
 RUN apt update && apt install -qqy wget
 
-RUN wget -q https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_linux_amd64 -O /usr/bin/cfssl && \
+RUN wget -q https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssl_1.6.5_linux_${TARGETARCH} -O /usr/bin/cfssl && \
     chmod a+x /usr/bin/cfssl
-RUN wget -q https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_linux_amd64 -O /usr/bin/cfssljson && \
+RUN wget -q https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssljson_1.6.5_linux_${TARGETARCH} -O /usr/bin/cfssljson && \
     chmod a+x /usr/bin/cfssljson
 
 # ----------------------------------------

--- a/docs/src/tutorials/testing.md
+++ b/docs/src/tutorials/testing.md
@@ -186,7 +186,7 @@ the flags `-v` for a verbose output and `-s` to print all output to
 the console instead of capturing it.
 
 ```
-pytest -v -s my-first-test.py
+uv run pytest -v -s my-first-test.py
 ```
 
 This should produce a lot of output, with the last few lines reading 
@@ -457,7 +457,7 @@ make docker-shell
 We can start our `pytest` test now. Remember the options `-v` and `-s`
 to print the logs to stdout instead of capturing them. 
 ```bash
-pytest -vs my-first-test.py
+uv run pytest -vs my-first-test.py
 ```
 
 After the test is finished you should see `passed` in the terminal.
@@ -517,7 +517,7 @@ make docker-shell
 
 Then we can start our REPL form inside the docker-shell.
 ```bash
-pytest -s examples/setup_repl.py
+uv run pytest -s examples/python/setup_repl.py
 ```
 
 You will see an output that looks similar to the following lines:


### PR DESCRIPTION
Add and refine arm64 support by introducing multi-arch Docker builds for both Bitcoin Core and Cloudflare’s CFSSL binaries, switching `uv sync --extra dev` to `uv sync --group dev`, and updating documentation to consistently use `uv run`. This improves cross-platform compatibility and streamlines the development workflow.