### PR TITLE
glclient: lift default decoding size

### DIFF
--- a/libs/gl-client/src/node/generic.rs
+++ b/libs/gl-client/src/node/generic.rs
@@ -66,6 +66,14 @@ where
     }
 
     // TODO Add a `streaming_call` for methods that return a stream to the client
+
+    pub fn max_decoding_message_size(mut self, limit: usize) -> Self
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    {
+        self.inner = self.inner.max_decoding_message_size(limit);
+        self
+    }
 }
 
 /// `tonic::client::Grpc<T>` requires a codec to convert between the


### PR DESCRIPTION
https://github.com/Blockstream/greenlight/issues/597 
Lift the maximum decoding message size from 4MB to 32MB by default.

Prevent large gRPC responses from failing.
Make it configurable via the Node builder.
We trust the server logic, so increasing the default is safe.