### PR TITLE
Add Domain Specific Error Handling for Trampoline Payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gl-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "dirs",
@@ -1504,6 +1504,16 @@ dependencies = [
  "tonic-build 0.3.1",
  "tower 0.3.1",
  "which 4.4.2",
+]
+
+[[package]]
+name = "gl-util"
+version = "0.1.0"
+dependencies = [
+ "bytes 1.10.1",
+ "serde",
+ "serde_json",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3483,15 +3493,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4098,7 +4108,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "libs/gl-plugin",
     "libs/gl-signerproxy",
     "libs/gl-cli",
+    "libs/gl-util",
 ]
 
 [workspace.dependencies]

--- a/libs/gl-client-py/tests/test_plugin.py
+++ b/libs/gl-client-py/tests/test_plugin.py
@@ -1,6 +1,7 @@
 from gltesting.fixtures import *
 from pyln.testing.utils import wait_for
 from pyln import grpc as clnpb
+import grpc
 import pytest
 import secrets
 from pathlib import Path
@@ -92,7 +93,7 @@ def test_trampoline_pay(bitcoind, clients, node_factory):
 
     res = n1.trampoline_pay(inv["bolt11"], bytes.fromhex(l2.info["id"]))
     assert res
-    assert len(res.payment_hash) == 32 # There was a confusion about hex/bytes return.
+    assert len(res.payment_hash) == 32  # There was a confusion about hex/bytes return.
 
     l2.rpc.unsetchecks()
 
@@ -124,7 +125,9 @@ def test_trampoline_pay(bitcoind, clients, node_factory):
 
     # calling `trampoline_pay` with an unkown tmrp_node_id must fail.
     with pytest.raises(
-        expected_exception=ValueError, match=r"Peer error: No such peer"
+        expected_exception=ValueError,
+
+        match=f"Unknown peer {l3.info['id']}",
     ):
         res = n1.trampoline_pay(inv["bolt11"], bytes.fromhex(l3.info["id"]))
 
@@ -134,12 +137,9 @@ def test_trampoline_pay(bitcoind, clients, node_factory):
     # trampoline payments must fail.
     with pytest.raises(
         expected_exception=ValueError,
-        match=r"Features \\\"[a-f0-9]+\\\" do not contain feature bit 427",
+        match="Peer doesn't suport trampoline payments",
     ):
         res = n1.trampoline_pay(inv["bolt11"], bytes.fromhex(l3.info["id"]))
-
-    res = n1.listpays()
-    print(f"LISTPAYS: {res}")
 
 
 def test_trampoline_multi_htlc(bitcoind, clients, node_factory):

--- a/libs/gl-plugin/Cargo.toml
+++ b/libs/gl-plugin/Cargo.toml
@@ -23,6 +23,7 @@ cln-rpc = { workspace = true }
 env_logger = "^0.7.1"
 futures = "0.3"
 gl-client = { version = "^0.3.0", path = "../gl-client" }
+gl-util = { version = "0.1", path = "../gl-util" }
 governor = { version = "0.5", default-features = false, features = ["std"] }
 hex = "0.4"
 hyper = "0.14.28"

--- a/libs/gl-plugin/src/lib.rs
+++ b/libs/gl-plugin/src/lib.rs
@@ -18,7 +18,7 @@ pub mod responses;
 pub mod stager;
 pub mod storage;
 pub mod tlv;
-mod tramp;
+pub mod tramp;
 #[cfg(unix)]
 mod unix;
 

--- a/libs/gl-plugin/src/tramp.rs
+++ b/libs/gl-plugin/src/tramp.rs
@@ -5,6 +5,7 @@ use cln_rpc::{
     ClnRpc, RpcError,
 };
 use futures::{future::join_all, FutureExt};
+use gl_util::error::{ClnRpcError, ErrorCode, ErrorStatusConversionExt, GreenlightError};
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -32,332 +33,6 @@ const PAY_UNPARSEABLE_ONION_MSG: &str = "Malformed error reply";
 const PAY_UNPARSEABLE_ONION_CODE: i32 = 202;
 // How long do we wait for channels to re-establish?
 const AWAIT_CHANNELS_TIMEOUT_SEC: u64 = 20;
-
-pub mod greenlight_error {
-    //! # Greenlight Error Module
-    //!
-    //! This module provides a comprehensive error handling system for
-    //! greenlight. It features a generic error type that can be customized with
-    //! module- or crate-specific error codes, while maintaining compatibility
-    //! with gRPC status codes and providing rich error context.
-    use bytes::Bytes;
-    use core::error::Error as StdError;
-    use serde::{Deserialize, Serialize};
-    use std::sync::Arc;
-
-    /// Trait for defining module-specific error codes.
-    ///
-    /// This trait should be implemented by enums that represent different error
-    /// categories in greenlight. The error codes should be unique integers that
-    /// can be serialized and transmitted over the network.
-    pub trait ErrorCode:
-        core::fmt::Debug + core::fmt::Display + Clone + Send + Sync + 'static
-    {
-        /// Returns the numeric error code for this error type.
-        ///
-        /// This code should be unique within your application and stable
-        /// across versions for backward compatibility.
-        fn code(&self) -> i32;
-
-        /// Attempts to construct an error code from its numeric representation.
-        ///
-        /// Returns `None` if the code is not recognized.
-        fn from_code(code: i32) -> Option<Self>
-        where
-            Self: Sized;
-    }
-
-    /// JSON structure for transmitting error details over gRPC.
-    ///
-    /// This structure is serialized into the `details` field of a
-    /// `tonic::Status` to provide structured error information that can be
-    /// parsed by clients.
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct GrpcErrorDetails {
-        pub code: i32,
-        /// Optional hint to help users resolve the issue
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub hint: Option<String>,
-    }
-
-    /// Extracted error information from a gRPC status.
-    ///
-    /// This structure contains all the error information that was transmitted
-    /// over gRPC, including both the standard gRPC fields and our custom
-    /// structured error details.
-    #[derive(Debug, Clone)]
-    pub struct GrpcErrorInfo {
-        pub code: i32,
-        pub message: String,
-        pub hint: Option<String>,
-        pub grpc_code: tonic::Code,
-    }
-
-    /// Attempts to parse structured error information from a `tonic::Status`.
-    ///
-    /// This implementation expects the status details to contain a JSON-encoded
-    /// `GrpcErrorDetails` structure. If parsing fails, a `serde_json::Error` is
-    /// returned.
-    impl TryFrom<tonic::Status> for GrpcErrorInfo {
-        type Error = serde_json::Error;
-
-        fn try_from(value: tonic::Status) -> std::result::Result<Self, Self::Error> {
-            let parsed = serde_json::from_slice::<GrpcErrorDetails>(&value.details())?;
-            Ok(GrpcErrorInfo {
-                code: parsed.code,
-                message: value.message().to_owned(),
-                hint: parsed.hint,
-                grpc_code: value.code(),
-            })
-        }
-    }
-
-    /// Extension trait for mapping error codes to gRPC status codes.
-    ///
-    /// This trait should be implemented alongside `ErrorCode` to define
-    /// how your greenlight-specific errors map to standard gRPC status codes.
-    pub trait ErrorStatusConversionExt: ErrorCode {
-        /// Maps this error to an appropriate gRPC status code.
-        ///
-        /// The returned status code should follow gRPC conventions:
-        /// See: https://grpc.io/docs/guides/status-codes/
-        fn status_code(&self) -> tonic::Code;
-    }
-
-    /// Generic error type that combines error codes with rich error context.
-    #[derive(Debug, Clone)]
-    pub struct GreenlightError<C: ErrorCode> {
-        /// Error code for categorization and programmatic handling
-        pub code: C,
-        /// User-facing error message
-        pub message: String,
-        /// Optional hint to help users resolve the issue
-        pub hint: Option<String>,
-        /// Context for debugging
-        pub context: Option<String>,
-        /// Source error chain for debugging
-        pub source: Option<Arc<dyn StdError + Send + Sync>>,
-    }
-
-    impl<C: ErrorCode> GreenlightError<C> {
-        /// Creates a new error with the given code and message.
-        pub fn new(code: C, message: impl Into<String>) -> Self {
-            Self {
-                code,
-                message: message.into(),
-                hint: None,
-                context: None,
-                source: None,
-            }
-        }
-
-        /// Adds a hint to help users resolve the issue.
-        ///
-        /// Hints should provide actionable guidance for end users.
-        pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
-            self.hint = Some(hint.into());
-            self
-        }
-
-        /// Adds internal context for debugging.
-        ///
-        /// Context is meant for developers and should include information
-        /// about what the system was doing when the error occurred.
-        /// TODO: currently unarmed, but can be used to log errors in a
-        /// standardized way in the future.
-        pub fn with_context(mut self, context: impl Into<String>) -> Self {
-            self.context = Some(context.into());
-            self
-        }
-
-        /// Adds a source error for error chaining.
-        ///
-        /// This is useful for preserving the original error that caused this error.
-        ///
-        pub fn with_source(mut self, source: impl StdError + Send + Sync + 'static) -> Self {
-            self.source = Some(Arc::new(source));
-            self
-        }
-
-        /// Adds a source error from an existing Arc.
-        ///
-        /// This is useful when forwarding errors that are already wrapped in an Arc,
-        /// avoiding unnecessary allocations.
-        pub fn with_source_arc(mut self, source: Arc<dyn StdError + Send + Sync>) -> Self {
-            self.source = Some(source);
-            self
-        }
-
-        /// Returns the numeric error code.
-        ///
-        /// This is a convenience method that calls `code()` on the error code.
-        pub fn code(&self) -> i32 {
-            self.code.code()
-        }
-
-        /// Converts this error to use a different error code type.
-        ///
-        /// This is useful when errors need to be converted between different
-        /// modules or layers that use different error code enums.
-        pub fn map_code<T: ErrorCode>(self, new_code: T) -> GreenlightError<T> {
-            GreenlightError {
-                code: new_code,
-                message: self.message,
-                hint: self.hint,
-                context: self.context,
-                source: self.source,
-            }
-        }
-    }
-
-    /// Displays the error message.
-    impl<C: ErrorCode> core::fmt::Display for GreenlightError<C> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            write!(f, "{}", self.message)
-        }
-    }
-
-    /// Implements the standard error trait for error chaining.
-    impl<C: ErrorCode> StdError for GreenlightError<C> {
-        fn source(&self) -> Option<&(dyn StdError + 'static)> {
-            self.source
-                .as_ref()
-                .map(|e| e.as_ref() as &(dyn StdError + 'static))
-        }
-    }
-
-    /// Converts a `GreenlightError` into a `tonic::Status` for gRPC transmission.
-    ///
-    /// The error details are JSON-encoded and included in the status details
-    /// field. If JSON serialization fails, a fallback JSON string is used.
-    impl<C: ErrorCode + ErrorStatusConversionExt> From<GreenlightError<C>> for tonic::Status {
-        fn from(value: GreenlightError<C>) -> Self {
-            let code = value.code.status_code();
-            let details: Bytes = serde_json::to_vec(&GrpcErrorDetails {
-                code: value.code(),
-                hint: value.hint.clone(),
-            })
-            .unwrap_or_else(|_| {
-                // Fallback to simple JSON if serialization fails
-                // This ensures we always send valid JSON even if something goes wrong
-                format!(
-                    "{{\"code\":{},\"message\":\"{}\"}}",
-                    value.code(),
-                    value.message,
-                )
-                .into_bytes()
-            })
-            .into();
-            tonic::Status::with_details(code, value.message, details)
-        }
-    }
-
-    /// Attempts to convert a `tonic::Status` back into a `GreenlightError`.
-    ///
-    /// This requires that:
-    /// 1. The status contains valid JSON details in the expected format
-    /// 2. The error code in the details can be mapped to a valid `C` variant
-    ///
-    /// Returns an `anyhow::Error` if parsing fails or the error code is unknown.
-    impl<C: ErrorCode> TryFrom<tonic::Status> for GreenlightError<C> {
-        type Error = anyhow::Error;
-
-        fn try_from(value: tonic::Status) -> std::result::Result<Self, Self::Error> {
-            let grpc_err: GrpcErrorInfo = value.try_into()?;
-            let code = C::from_code(grpc_err.code)
-                .ok_or_else(|| anyhow::anyhow!("unknown error code: {}", grpc_err.code))?;
-            Ok(Self {
-                code,
-                message: grpc_err.message,
-                hint: grpc_err.hint,
-                context: None,
-                source: None,
-            })
-        }
-    }
-
-    #[cfg(test)]
-    mod test {
-        use super::*;
-
-        #[test]
-        fn test_status_conversion() {
-            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-            enum TestErrorCodes {
-                FailedPrecondition = 101,
-                NotFound = 202,
-            }
-
-            impl ErrorCode for TestErrorCodes {
-                fn code(&self) -> i32 {
-                    *self as i32
-                }
-
-                fn from_code(_code: i32) -> Option<Self>
-                where
-                    Self: Sized,
-                {
-                    unimplemented!()
-                }
-            }
-
-            impl core::fmt::Display for TestErrorCodes {
-                fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    unimplemented!()
-                }
-            }
-
-            impl ErrorStatusConversionExt for TestErrorCodes {
-                fn status_code(&self) -> tonic::Code {
-                    match self {
-                        TestErrorCodes::FailedPrecondition => tonic::Code::FailedPrecondition,
-                        TestErrorCodes::NotFound => tonic::Code::NotFound,
-                    }
-                }
-            }
-
-            type TestError = GreenlightError<TestErrorCodes>;
-
-            let t_err = TestError::new(TestErrorCodes::FailedPrecondition, "a failed precondition")
-                .with_hint("How to resolve it");
-            let status: tonic::Status = t_err.clone().into();
-            assert_eq!(status.message(), t_err.message);
-
-            let mut details: serde_json::Value = serde_json::from_slice(status.details()).unwrap();
-            assert_eq!(
-                details["code"].take(),
-                TestErrorCodes::FailedPrecondition.code()
-            );
-            assert_eq!(details["hint"].take(), "How to resolve it");
-        }
-    }
-}
-
-use greenlight_error::{ErrorCode, ErrorStatusConversionExt, GreenlightError};
-
-/// Type alias for Core Lightning RPC error codes.
-///
-/// CLN uses specific numeric codes to indicate different types of failures
-/// in payment operations. This type preserves the original error code
-/// for debugging and logging purposes.
-pub type ClnRpcError = i32;
-
-/// Implementation of `ErrorCode` for CLN RPC errors.
-///
-/// This implementation treats all i32 values as valid error codes,
-/// allowing us to preserve any error code returned by CLN without loss.
-impl ErrorCode for ClnRpcError {
-    fn code(&self) -> i32 {
-        *self
-    }
-
-    fn from_code(code: i32) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        Some(code)
-    }
-}
 
 /// Converts Core Lightning RPC errors into trampoline errors.
 ///
@@ -511,16 +186,46 @@ impl ErrorStatusConversionExt for TrampolineErrCode {
     }
 }
 
+pub struct TrampolineError(pub GreenlightError<TrampolineErrCode>);
+
+impl core::ops::Deref for TrampolineError {
+    type Target = GreenlightError<TrampolineErrCode>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Implement From for easy conversion
+impl From<GreenlightError<TrampolineErrCode>> for TrampolineError {
+    fn from(err: GreenlightError<TrampolineErrCode>) -> Self {
+        TrampolineError(err)
+    }
+}
+
 /// Type aliases for convenience.
-pub type TrampolineError = GreenlightError<TrampolineErrCode>;
+// pub type TrampolineError = GreenlightError<TrampolineErrCode>;
 type Result<T, E = TrampolineError> = core::result::Result<T, E>;
+
+/// Needed to bypass rusts orphan rule.
+// trait TrampolineErrorExt {
+//     fn feature_not_supported(features: impl Into<String>) -> Self;
+//     fn invalid_node_id(source: impl StdError + Send + Sync + 'static) -> Self;
+//     fn network(reason: impl Into<String>) -> Self;
+//     fn internal(message: impl Into<String>) -> Self;
+// }
 
 /// TrampolineError Convenience Constructors
 impl TrampolineError {
+    fn new(code: TrampolineErrCode, message: impl Into<String>) -> Self {
+        TrampolineError(GreenlightError::new(code, message))
+    }
+
+    // impl TrampolineErrorExt for TrampolineError {
     /// Creates an error indicating that the peer doesn't support required
     /// trampoline features.
-    pub fn feature_not_supported(features: impl Into<String>) -> Self {
-        TrampolineError::new(
+    fn feature_not_supported(features: impl Into<String>) -> Self {
+        Self::new(
             TrampolineErrCode::FeatureNotSupported,
             format!("Peer doesn't suport trampoline payments"),
         )
@@ -529,7 +234,7 @@ impl TrampolineError {
     }
 
     /// Creates an error for invalid node ID format.
-    pub fn invalid_node_id(source: impl StdError + Send + Sync + 'static) -> Self {
+    fn invalid_node_id(source: impl StdError + Send + Sync + 'static) -> Self {
         TrampolineError::new(
             TrampolineErrCode::InvalidNodeId,
             format!("Got an invalid node id: {}", source.to_string()),
@@ -539,7 +244,7 @@ impl TrampolineError {
     }
 
     /// Creates a network error for Core Lightning connection failures.
-    pub fn network(reason: impl Into<String>) -> Self {
+    fn network(reason: impl Into<String>) -> Self {
         TrampolineError::new(
             TrampolineErrCode::NetworkError,
             format!(
@@ -550,7 +255,7 @@ impl TrampolineError {
     }
 
     /// Creates an internal error for unexpected failures.
-    pub fn internal(message: impl Into<String>) -> Self {
+    fn internal(message: impl Into<String>) -> Self {
         let msg = message.into();
         debug!(
             "Something unexpected happened during trampoline_pay: {}",

--- a/libs/gl-plugin/src/tramp.rs
+++ b/libs/gl-plugin/src/tramp.rs
@@ -32,6 +32,306 @@ const PAY_UNPARSEABLE_ONION_CODE: i32 = 202;
 // How long do we wait for channels to re-establish?
 const AWAIT_CHANNELS_TIMEOUT_SEC: u64 = 20;
 
+pub mod greenlight_error {
+    //! # Greenlight Error Module
+    //!
+    //! This module provides a comprehensive error handling system for
+    //! greenlight. It features a generic error type that can be customized with
+    //! module- or crate-specific error codes, while maintaining compatibility
+    //! with gRPC status codes and providing rich error context.
+    use bytes::Bytes;
+    use core::error::Error as StdError;
+    use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
+
+    /// Trait for defining module-specific error codes.
+    ///
+    /// This trait should be implemented by enums that represent different error
+    /// categories in greenlight. The error codes should be unique integers that
+    /// can be serialized and transmitted over the network.
+    pub trait ErrorCode:
+        core::fmt::Debug + core::fmt::Display + Clone + Send + Sync + 'static
+    {
+        /// Returns the numeric error code for this error type.
+        ///
+        /// This code should be unique within your application and stable
+        /// across versions for backward compatibility.
+        fn code(&self) -> i32;
+
+        /// Attempts to construct an error code from its numeric representation.
+        ///
+        /// Returns `None` if the code is not recognized.
+        fn from_code(code: i32) -> Option<Self>
+        where
+            Self: Sized;
+    }
+
+    /// JSON structure for transmitting error details over gRPC.
+    ///
+    /// This structure is serialized into the `details` field of a
+    /// `tonic::Status` to provide structured error information that can be
+    /// parsed by clients.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct GrpcErrorDetails {
+        pub code: i32,
+        /// Optional hint to help users resolve the issue
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub hint: Option<String>,
+    }
+
+    /// Extracted error information from a gRPC status.
+    ///
+    /// This structure contains all the error information that was transmitted
+    /// over gRPC, including both the standard gRPC fields and our custom
+    /// structured error details.
+    #[derive(Debug, Clone)]
+    pub struct GrpcErrorInfo {
+        pub code: i32,
+        pub message: String,
+        pub hint: Option<String>,
+        pub grpc_code: tonic::Code,
+    }
+
+    /// Attempts to parse structured error information from a `tonic::Status`.
+    ///
+    /// This implementation expects the status details to contain a JSON-encoded
+    /// `GrpcErrorDetails` structure. If parsing fails, a `serde_json::Error` is
+    /// returned.
+    impl TryFrom<tonic::Status> for GrpcErrorInfo {
+        type Error = serde_json::Error;
+
+        fn try_from(value: tonic::Status) -> std::result::Result<Self, Self::Error> {
+            let parsed = serde_json::from_slice::<GrpcErrorDetails>(&value.details())?;
+            Ok(GrpcErrorInfo {
+                code: parsed.code,
+                message: value.message().to_owned(),
+                hint: parsed.hint,
+                grpc_code: value.code(),
+            })
+        }
+    }
+
+    /// Extension trait for mapping error codes to gRPC status codes.
+    ///
+    /// This trait should be implemented alongside `ErrorCode` to define
+    /// how your greenlight-specific errors map to standard gRPC status codes.
+    pub trait ErrorStatusConversionExt: ErrorCode {
+        /// Maps this error to an appropriate gRPC status code.
+        ///
+        /// The returned status code should follow gRPC conventions:
+        /// See: https://grpc.io/docs/guides/status-codes/
+        fn status_code(&self) -> tonic::Code;
+    }
+
+    /// Generic error type that combines error codes with rich error context.
+    #[derive(Debug, Clone)]
+    pub struct GreenlightError<C: ErrorCode> {
+        /// Error code for categorization and programmatic handling
+        pub code: C,
+        /// User-facing error message
+        pub message: String,
+        /// Optional hint to help users resolve the issue
+        pub hint: Option<String>,
+        /// Context for debugging
+        pub context: Option<String>,
+        /// Source error chain for debugging
+        pub source: Option<Arc<dyn StdError + Send + Sync>>,
+    }
+
+    impl<C: ErrorCode> GreenlightError<C> {
+        /// Creates a new error with the given code and message.
+        pub fn new(code: C, message: impl Into<String>) -> Self {
+            Self {
+                code,
+                message: message.into(),
+                hint: None,
+                context: None,
+                source: None,
+            }
+        }
+
+        /// Adds a hint to help users resolve the issue.
+        ///
+        /// Hints should provide actionable guidance for end users.
+        pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+            self.hint = Some(hint.into());
+            self
+        }
+
+        /// Adds internal context for debugging.
+        ///
+        /// Context is meant for developers and should include information
+        /// about what the system was doing when the error occurred.
+        /// TODO: currently unarmed, but can be used to log errors in a
+        /// standardized way in the future.
+        pub fn with_context(mut self, context: impl Into<String>) -> Self {
+            self.context = Some(context.into());
+            self
+        }
+
+        /// Adds a source error for error chaining.
+        ///
+        /// This is useful for preserving the original error that caused this error.
+        ///
+        pub fn with_source(mut self, source: impl StdError + Send + Sync + 'static) -> Self {
+            self.source = Some(Arc::new(source));
+            self
+        }
+
+        /// Adds a source error from an existing Arc.
+        ///
+        /// This is useful when forwarding errors that are already wrapped in an Arc,
+        /// avoiding unnecessary allocations.
+        pub fn with_source_arc(mut self, source: Arc<dyn StdError + Send + Sync>) -> Self {
+            self.source = Some(source);
+            self
+        }
+
+        /// Returns the numeric error code.
+        ///
+        /// This is a convenience method that calls `code()` on the error code.
+        pub fn code(&self) -> i32 {
+            self.code.code()
+        }
+
+        /// Converts this error to use a different error code type.
+        ///
+        /// This is useful when errors need to be converted between different
+        /// modules or layers that use different error code enums.
+        pub fn map_code<T: ErrorCode>(self, new_code: T) -> GreenlightError<T> {
+            GreenlightError {
+                code: new_code,
+                message: self.message,
+                hint: self.hint,
+                context: self.context,
+                source: self.source,
+            }
+        }
+    }
+
+    /// Displays the error message.
+    impl<C: ErrorCode> core::fmt::Display for GreenlightError<C> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    /// Implements the standard error trait for error chaining.
+    impl<C: ErrorCode> StdError for GreenlightError<C> {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            self.source
+                .as_ref()
+                .map(|e| e.as_ref() as &(dyn StdError + 'static))
+        }
+    }
+
+    /// Converts a `GreenlightError` into a `tonic::Status` for gRPC transmission.
+    ///
+    /// The error details are JSON-encoded and included in the status details
+    /// field. If JSON serialization fails, a fallback JSON string is used.
+    impl<C: ErrorCode + ErrorStatusConversionExt> From<GreenlightError<C>> for tonic::Status {
+        fn from(value: GreenlightError<C>) -> Self {
+            let code = value.code.status_code();
+            let details: Bytes = serde_json::to_vec(&GrpcErrorDetails {
+                code: value.code(),
+                hint: value.hint.clone(),
+            })
+            .unwrap_or_else(|_| {
+                // Fallback to simple JSON if serialization fails
+                // This ensures we always send valid JSON even if something goes wrong
+                format!(
+                    "{{\"code\":{},\"message\":\"{}\"}}",
+                    value.code(),
+                    value.message,
+                )
+                .into_bytes()
+            })
+            .into();
+            tonic::Status::with_details(code, value.message, details)
+        }
+    }
+
+    /// Attempts to convert a `tonic::Status` back into a `GreenlightError`.
+    ///
+    /// This requires that:
+    /// 1. The status contains valid JSON details in the expected format
+    /// 2. The error code in the details can be mapped to a valid `C` variant
+    ///
+    /// Returns an `anyhow::Error` if parsing fails or the error code is unknown.
+    impl<C: ErrorCode> TryFrom<tonic::Status> for GreenlightError<C> {
+        type Error = anyhow::Error;
+
+        fn try_from(value: tonic::Status) -> std::result::Result<Self, Self::Error> {
+            let grpc_err: GrpcErrorInfo = value.try_into()?;
+            let code = C::from_code(grpc_err.code)
+                .ok_or_else(|| anyhow::anyhow!("unknown error code: {}", grpc_err.code))?;
+            Ok(Self {
+                code,
+                message: grpc_err.message,
+                hint: grpc_err.hint,
+                context: None,
+                source: None,
+            })
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn test_status_conversion() {
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+            enum TestErrorCodes {
+                FailedPrecondition = 101,
+                NotFound = 202,
+            }
+
+            impl ErrorCode for TestErrorCodes {
+                fn code(&self) -> i32 {
+                    *self as i32
+                }
+
+                fn from_code(_code: i32) -> Option<Self>
+                where
+                    Self: Sized,
+                {
+                    unimplemented!()
+                }
+            }
+
+            impl core::fmt::Display for TestErrorCodes {
+                fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    unimplemented!()
+                }
+            }
+
+            impl ErrorStatusConversionExt for TestErrorCodes {
+                fn status_code(&self) -> tonic::Code {
+                    match self {
+                        TestErrorCodes::FailedPrecondition => tonic::Code::FailedPrecondition,
+                        TestErrorCodes::NotFound => tonic::Code::NotFound,
+                    }
+                }
+            }
+
+            type TestError = GreenlightError<TestErrorCodes>;
+
+            let t_err = TestError::new(TestErrorCodes::FailedPrecondition, "a failed precondition")
+                .with_hint("How to resolve it");
+            let status: tonic::Status = t_err.clone().into();
+            assert_eq!(status.message(), t_err.message);
+
+            let mut details: serde_json::Value = serde_json::from_slice(status.details()).unwrap();
+            assert_eq!(
+                details["code"].take(),
+                TestErrorCodes::FailedPrecondition.code()
+            );
+            assert_eq!(details["hint"].take(), "How to resolve it");
+        }
+    }
+}
+
 fn feature_guard(features: impl Into<Vec<u8>>, feature_bit: usize) -> Result<()> {
     let mut features = features.into();
     features.reverse();

--- a/libs/gl-util/Cargo.toml
+++ b/libs/gl-util/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gl-util"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bytes = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+tonic = "0.11"

--- a/libs/gl-util/src/error.rs
+++ b/libs/gl-util/src/error.rs
@@ -1,0 +1,341 @@
+//! # Greenlight Error Module
+//!
+//! This module provides a comprehensive error handling system for
+//! greenlight. It features a generic error type that can be customized with
+//! module- or crate-specific error codes, while maintaining compatibility
+//! with gRPC status codes and providing rich error context.
+use bytes::Bytes;
+use core::error::Error as StdError;
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::sync::Arc;
+use tonic;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParsingError(String);
+
+impl core::fmt::Display for ParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "could not parse error: {}", self.0)
+    }
+}
+
+impl StdError for ParsingError {}
+
+// Convenient macro for creating ParsingError
+macro_rules! parsing_error {
+    ($($arg:tt)*) => {
+        ParsingError(format!($($arg)*))
+    };
+}
+
+/// Trait for defining module-specific error codes.
+///
+/// This trait should be implemented by enums that represent different error
+/// categories in greenlight. The error codes should be unique integers that
+/// can be serialized and transmitted over the network.
+pub trait ErrorCode: core::fmt::Debug + core::fmt::Display + Clone + Send + Sync + 'static {
+    /// Returns the numeric error code for this error type.
+    ///
+    /// This code should be unique within your application and stable
+    /// across versions for backward compatibility.
+    fn code(&self) -> i32;
+
+    /// Attempts to construct an error code from its numeric representation.
+    ///
+    /// Returns `None` if the code is not recognized.
+    fn from_code(code: i32) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+/// JSON structure for transmitting error details over gRPC.
+///
+/// This structure is serialized into the `details` field of a
+/// `tonic::Status` to provide structured error information that can be
+/// parsed by clients.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GrpcErrorDetails {
+    pub code: i32,
+    /// Optional hint to help users resolve the issue
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+/// Extracted error information from a gRPC status.
+///
+/// This structure contains all the error information that was transmitted
+/// over gRPC, including both the standard gRPC fields and our custom
+/// structured error details.
+#[derive(Debug, Clone)]
+pub struct GrpcErrorInfo {
+    pub code: i32,
+    pub message: String,
+    pub hint: Option<String>,
+    pub grpc_code: tonic::Code,
+}
+
+/// Attempts to parse structured error information from a `tonic::Status`.
+///
+/// This implementation expects the status details to contain a JSON-encoded
+/// `GrpcErrorDetails` structure. If parsing fails, a `serde_json::Error` is
+/// returned.
+impl TryFrom<tonic::Status> for GrpcErrorInfo {
+    type Error = serde_json::Error;
+
+    fn try_from(value: tonic::Status) -> std::result::Result<Self, Self::Error> {
+        let parsed = serde_json::from_slice::<GrpcErrorDetails>(&value.details())?;
+        Ok(GrpcErrorInfo {
+            code: parsed.code,
+            message: value.message().to_owned(),
+            hint: parsed.hint,
+            grpc_code: value.code(),
+        })
+    }
+}
+
+/// Extension trait for mapping error codes to gRPC status codes.
+///
+/// This trait should be implemented alongside `ErrorCode` to define
+/// how your greenlight-specific errors map to standard gRPC status codes.
+pub trait ErrorStatusConversionExt: ErrorCode {
+    /// Maps this error to an appropriate gRPC status code.
+    ///
+    /// The returned status code should follow gRPC conventions:
+    /// See: https://grpc.io/docs/guides/status-codes/
+    fn status_code(&self) -> tonic::Code;
+}
+
+/// Generic error type that combines error codes with rich error context.
+#[derive(Debug, Clone)]
+pub struct GreenlightError<C: ErrorCode> {
+    /// Error code for categorization and programmatic handling
+    pub code: C,
+    /// User-facing error message
+    pub message: String,
+    /// Optional hint to help users resolve the issue
+    pub hint: Option<String>,
+    /// Context for debugging
+    pub context: Option<String>,
+    /// Source error chain for debugging
+    pub source: Option<Arc<dyn StdError + Send + Sync>>,
+}
+
+impl<C: ErrorCode> GreenlightError<C> {
+    /// Creates a new error with the given code and message.
+    pub fn new(code: C, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            hint: None,
+            context: None,
+            source: None,
+        }
+    }
+
+    /// Adds a hint to help users resolve the issue.
+    ///
+    /// Hints should provide actionable guidance for end users.
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    /// Adds internal context for debugging.
+    ///
+    /// Context is meant for developers and should include information
+    /// about what the system was doing when the error occurred.
+    /// TODO: currently unarmed, but can be used to log errors in a
+    /// standardized way in the future.
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.context = Some(context.into());
+        self
+    }
+
+    /// Adds a source error for error chaining.
+    ///
+    /// This is useful for preserving the original error that caused this error.
+    ///
+    pub fn with_source(mut self, source: impl StdError + Send + Sync + 'static) -> Self {
+        self.source = Some(Arc::new(source));
+        self
+    }
+
+    /// Adds a source error from an existing Arc.
+    ///
+    /// This is useful when forwarding errors that are already wrapped in an Arc,
+    /// avoiding unnecessary allocations.
+    pub fn with_source_arc(mut self, source: Arc<dyn StdError + Send + Sync>) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    /// Returns the numeric error code.
+    ///
+    /// This is a convenience method that calls `code()` on the error code.
+    pub fn code(&self) -> i32 {
+        self.code.code()
+    }
+
+    /// Converts this error to use a different error code type.
+    ///
+    /// This is useful when errors need to be converted between different
+    /// modules or layers that use different error code enums.
+    pub fn map_code<T: ErrorCode>(self, new_code: T) -> GreenlightError<T> {
+        GreenlightError {
+            code: new_code,
+            message: self.message,
+            hint: self.hint,
+            context: self.context,
+            source: self.source,
+        }
+    }
+}
+
+/// Displays the error message.
+impl<C: ErrorCode> core::fmt::Display for GreenlightError<C> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// Implements the standard error trait for error chaining.
+impl<C: ErrorCode> StdError for GreenlightError<C> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_ref()
+            .map(|e| e.as_ref() as &(dyn StdError + 'static))
+    }
+}
+
+/// Converts a `GreenlightError` into a `tonic::Status` for gRPC transmission.
+///
+/// The error details are JSON-encoded and included in the status details
+/// field. If JSON serialization fails, a fallback JSON string is used.
+impl<C: ErrorCode + ErrorStatusConversionExt> From<GreenlightError<C>> for tonic::Status {
+    fn from(value: GreenlightError<C>) -> Self {
+        let code = value.code.status_code();
+        let details: Bytes = serde_json::to_vec(&GrpcErrorDetails {
+            code: value.code(),
+            hint: value.hint.clone(),
+        })
+        .unwrap_or_else(|_| {
+            // Fallback to simple JSON if serialization fails
+            // This ensures we always send valid JSON even if something goes wrong
+            format!(
+                "{{\"code\":{},\"message\":\"{}\"}}",
+                value.code(),
+                value.message,
+            )
+            .into_bytes()
+        })
+        .into();
+        tonic::Status::with_details(code, value.message, details)
+    }
+}
+
+/// Attempts to convert a `tonic::Status` back into a `GreenlightError`.
+///
+/// This requires that:
+/// 1. The status contains valid JSON details in the expected format
+/// 2. The error code in the details can be mapped to a valid `C` variant
+///
+/// Returns an `anyhow::Error` if parsing fails or the error code is unknown.
+impl<C: ErrorCode> TryFrom<tonic::Status> for GreenlightError<C> {
+    type Error = ParsingError;
+
+    fn try_from(value: tonic::Status) -> std::result::Result<Self, Self::Error> {
+        let grpc_err: GrpcErrorInfo = value
+            .try_into()
+            .map_err(|e| parsing_error!("failed to convert Status into GrpcErrorInfo {}", e))?;
+        let code = C::from_code(grpc_err.code)
+            .ok_or_else(|| parsing_error!("unknown error code: {}", grpc_err.code))?;
+        Ok(Self {
+            code,
+            message: grpc_err.message,
+            hint: grpc_err.hint,
+            context: None,
+            source: None,
+        })
+    }
+}
+
+/// Type alias for Core Lightning RPC error codes.
+///
+/// CLN uses specific numeric codes to indicate different types of failures
+/// in payment operations. This type preserves the original error code
+/// for debugging and logging purposes.
+pub type ClnRpcError = i32;
+
+/// Implementation of `ErrorCode` for CLN RPC errors.
+///
+/// This implementation treats all i32 values as valid error codes,
+/// allowing us to preserve any error code returned by CLN without loss.
+impl ErrorCode for ClnRpcError {
+    fn code(&self) -> i32 {
+        *self
+    }
+
+    fn from_code(code: i32) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        Some(code)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_status_conversion() {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        enum TestErrorCodes {
+            FailedPrecondition = 101,
+            NotFound = 202,
+        }
+
+        impl ErrorCode for TestErrorCodes {
+            fn code(&self) -> i32 {
+                *self as i32
+            }
+
+            fn from_code(_code: i32) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                unimplemented!()
+            }
+        }
+
+        impl core::fmt::Display for TestErrorCodes {
+            fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                unimplemented!()
+            }
+        }
+
+        impl ErrorStatusConversionExt for TestErrorCodes {
+            fn status_code(&self) -> tonic::Code {
+                match self {
+                    TestErrorCodes::FailedPrecondition => tonic::Code::FailedPrecondition,
+                    TestErrorCodes::NotFound => tonic::Code::NotFound,
+                }
+            }
+        }
+
+        type TestError = GreenlightError<TestErrorCodes>;
+
+        let t_err = TestError::new(TestErrorCodes::FailedPrecondition, "a failed precondition")
+            .with_hint("How to resolve it");
+        let status: tonic::Status = t_err.clone().into();
+        assert_eq!(status.message(), t_err.message);
+
+        let mut details: serde_json::Value = serde_json::from_slice(status.details()).unwrap();
+        assert_eq!(
+            details["code"].take(),
+            TestErrorCodes::FailedPrecondition.code()
+        );
+        assert_eq!(details["hint"].take(), "How to resolve it");
+    }
+}

--- a/libs/gl-util/src/lib.rs
+++ b/libs/gl-util/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod error;


### PR DESCRIPTION
This PR introduces a comprehensive error handling framework for trampoline payments, replacing generic `anyhow::Error` usage with strongly-typed, domain-specific errors. The error handling provides better error categorization, improved diagnostics, and seamless gRPC integration. It also adds rich error context with hints for developers and users while surviving serialization into gRPC statuses for usage across service boundaries. 