### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures",
  "gl-client",
+ "gl-util",
  "governor",
  "hex",
  "hyper 0.14.32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,7 @@ name = "gl-util"
 version = "0.1.0"
 dependencies = [
  "bytes 1.10.1",
+ "cln-rpc",
  "serde",
  "serde_json",
  "tonic 0.11.0",

--- a/libs/gl-plugin/src/lib.rs
+++ b/libs/gl-plugin/src/lib.rs
@@ -6,6 +6,9 @@ use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
+#[macro_use(error)]
+extern crate gl_util;
+
 mod awaitables;
 pub mod config;
 pub mod hsm;

--- a/libs/gl-plugin/src/tramp.rs
+++ b/libs/gl-plugin/src/tramp.rs
@@ -216,6 +216,14 @@ impl From<GreenlightError<TrampolineErrCode>> for TrampolineError {
 /// Type alias for convenience.
 type Result<T, E = TrampolineError> = core::result::Result<T, E>;
 
+/// Needed to bypass rusts orphan rule.
+// trait TrampolineErrorExt {
+//     fn feature_not_supported(features: impl Into<String>) -> Self;
+//     fn invalid_node_id(source: impl StdError + Send + Sync + 'static) -> Self;
+//     fn network(reason: impl Into<String>) -> Self;
+//     fn internal(message: impl Into<String>) -> Self;
+// }
+
 /// TrampolineError Convenience Constructors
 impl TrampolineError {
     // Delegate builder methods, wrapping the result
@@ -286,7 +294,11 @@ fn feature_guard(features: impl Into<Vec<u8>>, feature_bit: usize) -> Result<()>
         return Err(TrampolineError::feature_not_supported(hex::encode(
             features,
         )));
-    }
+        poline error codes to numeric values and back.
+        ///
+        /// Error code allocation:
+        /// - 42701-42714: Reserved for trampoline-specific errors
+        /// - Other ranges: CLN RPC error codes (see comments in from_code)}
     Ok(())
 }
 

--- a/libs/gl-util/Cargo.toml
+++ b/libs/gl-util/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 bytes = "1.10"
+cln-rpc = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tonic = "0.11"


### PR DESCRIPTION
This removes the direct implementation of RpcErrors and replaces it with a conversion trait for modularity. This PR also cleans up some boilerplate and naming conventions and adds a convenience macro to allow for easy error creation.
