### PR TITLE
gl-client-py: make retry_for optional

### DIFF
--- a/libs/gl-client-py/glclient/__init__.py
+++ b/libs/gl-client-py/glclient/__init__.py
@@ -397,7 +397,7 @@ class Node(object):
         self,
         bolt11: str,
         amount_msat: Optional[clnpb.Amount] = None,
-        retry_for: int = 0,
+        retry_for: Optional[int] = None,
         maxfee: Optional[clnpb.Amount] = None,
         maxfeepercent: Optional[float] = None,
     ) -> clnpb.PayResponse:


### PR DESCRIPTION
retry_for argument in pay is optional in core-lightning let's keep it that way also during tests.

We were trying to intercept pay requests and redirect them to xpay and renepay but with retry_for=0 renepay would inmediately fail during testing sessions. We were not expecting that the value of retry_for was being set to 0 instead
of being forwarded as an optional argument.