### PR TITLE
signer: Allow the signer to go through the node domain

### DIFF
--- a/examples/rust/snippets/getting_started.rs
+++ b/examples/rust/snippets/getting_started.rs
@@ -45,7 +45,7 @@ async fn create_seed() -> Vec<u8> {
     let m = Mnemonic::generate_in_with(&mut rng, Language::English, 24).unwrap();
 
     //Show seed phrase to user
-    let _phrase = m.word_iter().fold("".to_string(), |c, n| c + " " + n);
+    let _phrase = m.words().fold("".to_string(), |c, n| c + " " + n);
 
     const EMPTY_PASSPHRASE: &str = "";
     let seed = &m.to_seed(EMPTY_PASSPHRASE)[0..32]; // Only need the first 32 bytes

--- a/libs/gl-plugin/src/node/mod.rs
+++ b/libs/gl-plugin/src/node/mod.rs
@@ -369,6 +369,7 @@ impl Node for PluginNodeServer {
                     req.request.signer_state.len()
                 );
 
+		eprintln!("WIRE: plugin -> signer: {:?}", req);
                 if let Err(e) = tx.send(Ok(req.request)).await {
                     warn!("Error streaming request {:?} to hsm_id={}", e, hsm_id);
                     break;
@@ -393,6 +394,7 @@ impl Node for PluginNodeServer {
             log::warn!("The above error was returned instead of a response.");
             return Ok(Response::new(pb::Empty::default()));
         }
+	eprintln!("WIRE: signer -> plugin: {:?}", req);
 
         // Create a state from the key-value-version tuples. Need to
         // convert here, since `pb` is duplicated in the two different

--- a/libs/gl-signerproxy/src/hsmproxy.rs
+++ b/libs/gl-signerproxy/src/hsmproxy.rs
@@ -4,7 +4,7 @@ use crate::pb::{hsm_client::HsmClient, Empty, HsmRequest, HsmRequestContext};
 use crate::wire::{DaemonConnection, Message};
 use anyhow::{anyhow, Context};
 use anyhow::{Error, Result};
-use log::{debug, error, info, warn};
+use log::{error, info, warn};
 use std::convert::TryFrom;
 use std::env;
 use std::os::unix::io::{AsRawFd, FromRawFd};


### PR DESCRIPTION
We were always pinning the TLS SNI domain to `localhost`. That worked
while we were using IP-based URIs to connect to the node. It does no
longer work with the node domain proxy which is behind a GCP anycast
load balancer, which drops connections claiming to be for `localhost`.

