### PR TITLE
ci: Add manual dry-run mode to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,19 +438,19 @@ jobs:
         if: steps.parse.outputs.dry_run == 'false'
         run: |
           echo "🚀 Publishing ${{ steps.parse.outputs.crate }} v${{ steps.parse.outputs.version }} to crates.io..."
-          
+
           # -p flag: Publish only this specific crate from the workspace
           # CARGO_REGISTRY_TOKEN: Authenticates with crates.io
           # This token should be added to GitHub Secrets as CRATES_IO_TOKEN
           cargo publish -p ${{ steps.parse.outputs.crate }}
-          
+
           echo "✅ Successfully published to crates.io!"
           echo "🔗 https://crates.io/crates/${{ steps.parse.outputs.crate }}"
-      env:
-        # The token is stored in GitHub Secrets for security
-        # To create one: https://crates.io/settings/tokens
-        # Add it to repo: Settings → Secrets and variables → Actions
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        env:
+          # The token is stored in GitHub Secrets for security
+          # To create one: https://crates.io/settings/tokens
+          # Add it to repo: Settings → Secrets and variables → Actions
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
       
       - name: Create GitHub Release
         if: steps.parse.outputs.dry_run == 'false'


### PR DESCRIPTION
## Summary

- Added `workflow_dispatch` trigger to the release workflow, allowing manual testing without publishing
- Modified tag parsing to support both tag-triggered releases and manual dry-run mode
- Added conditionals to skip `cargo publish` and GitHub release creation during dry-runs
- Added a summary step at the end of dry-runs showing what checks passed and how to publish for real

## Changes

The workflow now supports two modes:

**Tag-triggered mode (existing behavior):**
- Push a tag like `mycrate-v1.2.3`
- All validation checks run
- Publishes to crates.io and creates GitHub release

**Manual dry-run mode (new):**
- Navigate to Actions → Publish Crate → Run workflow
- Enter crate name and version
- All validation checks run (version match, changelog format, changelog entry, semver, tests)
- Skips `cargo publish` and GitHub release creation
- Shows summary with instructions to create the actual tag

## Test plan

- [x] Verify workflow file syntax is valid
- [ ] Test manual dry-run trigger from GitHub Actions UI
- [ ] Verify dry-run skips publish steps
- [ ] Verify tag-triggered mode still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)