### PR TITLE
gl-testserver: Add build-system table for build instructions

### DIFF
--- a/libs/gl-testserver/pyproject.toml
+++ b/libs/gl-testserver/pyproject.toml
@@ -15,3 +15,15 @@ gltestserver = 'gltestserver.__main__:cli'
 
 [tool.uv.sources]
 gl-testing = { workspace = true }
+
+[tool.uv]
+package = true
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = [
+    "gltestserver",
+]


### PR DESCRIPTION
The `libs/gl-testserver/pyproject.toml` file is missing the [build-system] table, which is strongly recommended for any Python project intended to be built and installed.

The [build-system] table is crucial because it defines two key things :
- requires: A list of dependencies needed to build your project.
- build-backend: The Python object that will perform the build.

Without this section, tools like `uv` and `pip` do not know how to build and install the package from its source, even if all other project metadata is correctly specified.