### PR TITLE
ci: Update checkout reference for doc deployment

### DIFF
--- a/.github/workflows/docs-action.yml
+++ b/.github/workflows/docs-action.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: testing-doc-snippets
+          ref: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 


### PR DESCRIPTION
I had unintentionally left the reference branch set from earlier testing and the action failed to build and deploy documentation with error `A branch or tag with the name 'testing-doc-snippets' could not be found`. 

This update ensures that the action now runs from the branch that triggered the workflow.

