### PR TITLE
sdk: Fix gl-sdk bindings generation for multiple OS

### DIFF
--- a/libs/gl-client-py/Makefile
+++ b/libs/gl-client-py/Makefile
@@ -39,8 +39,8 @@ pygrpc: ${PROTOSRC}
 	cd ${PYDIR}; uv run python -m grpc_tools.protoc ${PYPROTOC_OPTS} glclient/greenlight.proto
 
 check-py:
-	#uv run --all-packages mypy ${PYDIR}/glclient
-	uv run --all-packages pytest tests -n $(shell nproc) ${PYDIR}/tests
+	#uv run --reinstall-package='gl-sdk' --all-packages mypy ${PYDIR}/glclient
+	uv run --reinstall-package='gl-sdk' --all-packages pytest tests -n $(shell nproc) ${PYDIR}/tests
 
 clean-py:
 	rm -f ${PYPROTOS} ${PYDIR}/build ${PYDIR}/dist

--- a/libs/gl-sdk/.tasks.yml
+++ b/libs/gl-sdk/.tasks.yml
@@ -1,5 +1,20 @@
 version: "3"
 
+vars:
+  LIB_EXT:
+    sh: |
+      case "$(uname -s)" in
+        Darwin*)
+          echo "dylib"
+          ;;
+        MINGW*|MSYS*|CYGWIN*)
+          echo "dll"
+          ;;
+        *)
+          echo "so"
+          ;;
+      esac
+
 tasks:
   build:
     desc: "Build the gl-sdk library"
@@ -20,8 +35,9 @@ tasks:
       - build-release
     cmds:
       - |
+        cp ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} ./libs/gl-sdk/glsdk/libglsdk.{{.LIB_EXT}};
         cargo run --bin uniffi-bindgen -- generate \
-          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.so \
+          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} \
           --language python \
           --out-dir ./libs/gl-sdk/bindings
 
@@ -32,8 +48,9 @@ tasks:
       - build-release
     cmds:
       - |
+        cp ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} ./libs/gl-sdk/glsdk/libglsdk.{{.LIB_EXT}};
         cargo run --bin uniffi-bindgen -- generate \
-          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.so \
+          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} \
           --language kotlin \
           --out-dir ./libs/gl-sdk/bindings
 
@@ -44,8 +61,9 @@ tasks:
       - build-release
     cmds:
       - |
+        cp ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} ./libs/gl-sdk/glsdk/libglsdk.{{.LIB_EXT}};
         cargo run --bin uniffi-bindgen -- generate \
-          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.so \
+          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} \
           --language swift \
           --out-dir ./libs/gl-sdk/bindings
 
@@ -56,8 +74,9 @@ tasks:
       - build-release
     cmds:
       - |
+        cp ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} ./libs/gl-sdk/glsdk/libglsdk.{{.LIB_EXT}};
         cargo run --bin uniffi-bindgen -- generate \
-          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.so \
+          --library ${CARGO_TARGET_DIR:-target}/release/libglsdk.{{.LIB_EXT}} \
           --language ruby \
           --out-dir ./libs/gl-sdk/bindings
 
@@ -106,6 +125,6 @@ tasks:
     cmds:
       - rm -rf ./bindings
       - rm -rf dist/ build/ *.egg-info
-      - rm -f glsdk/*.so glsdk/glsdk.py
+      - rm -f glsdk/*.{{.LIB_EXT}} glsdk/glsdk.py
       - find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
       - find . -type f -name "*.pyc" -delete

--- a/libs/gl-sdk/hooks/libglsdk_force_include.py
+++ b/libs/gl-sdk/hooks/libglsdk_force_include.py
@@ -1,0 +1,23 @@
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+import platform
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version, build_data):
+        """
+        Sets force-include option for glsdk/libglsdk shared lib.
+
+        Does the same as [tool.hatch.build.targets.wheel.force-include], however
+        assumes system OS and based on that sets the correct extension.
+        """
+        system = platform.system()
+
+        match system:
+            case "Darwin":
+                lib_ext = ".dylib"
+            case "Windows":
+                lib_ext = ".dll"
+            case _:
+                lib_ext = ".so"
+
+        shared_file = f"glsdk/libglsdk{lib_ext}"
+        build_data['force_include'][shared_file] = shared_file

--- a/libs/gl-sdk/pyproject.toml
+++ b/libs/gl-sdk/pyproject.toml
@@ -17,8 +17,8 @@ build-backend = "hatchling.build"
 packages = ["glsdk"]
 
 # Include the shared library as package data
-[tool.hatch.build.targets.wheel.force-include]
-"glsdk/libglsdk.so" = "glsdk/libglsdk.so"
+[tool.hatch.build.hooks.custom]
+path = "hooks/libglsdk_force_include.py"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
# Problem
UNIFFI crates a dynamic lib file which is used for generating bindings for different languages. On different OS dynamic files have different extension: Linux - `.os`, Darwin - `.dylib`, Windows - `.dll`. For now, only a Linux case is handled (`.os` files are supported).

# Solution
In order to use a dynamic library file for bindings generation on multiple OS, OS should be defined in `.task.yaml` via shell command. Moreover, `bindings-...` tasks scripts should be expanded to copy `libglsdk.*` file from the `target` directory into the `glsdk` directory.

The same should be done for `pyproject.toml` file which uses `force-include` option for checking whether `libglsdk.*` is included into `glsdk` directory. Since it is not possible to follow the same approach as it is introduced in `.task.yaml`, `pyproject.toml` should use a build hook with custom force inclusion Python script. 

Using hooks for `pyproject.toml` file result some changes in `uv sync` command. Since `uv sync` builds hatch module only once, build hook is also called only once. Future `uv sync` calls will omit the hook, so adding `--reinstall-package='gl-sdk'` flag will reinstall gl-sdk package every time the command is executed and check for `libglsdk.*`. Also, I do not think that it is necessary to change `uv sync` command in Dockerfiles since gl-sdk should be rebuilt each time (assuming PR #639) resulting hook call.

# Changes
- add OS recognition via shell script to `.task.yaml`;
- add `libglsdk_force_include.py` hook to handle force inclusion of `libglsdk.*` dynamic lib;
- add `--reinstall-package='gl-sdk'` to `libs/gl-client-py/Makefile` `uv sync` command to handle force-inclusion hook.