### PR TITLE
bindings: update build for swift bindings

### DIFF
--- a/build/.tasks.yml
+++ b/build/.tasks.yml
@@ -37,7 +37,10 @@ tasks:
       - ios-sim
     cmds:
       - cargo run --bin uniffi-bindgen -- generate --library ./target/aarch64-apple-ios/release/libglsdk.a --language swift --out-dir ./target/swift
-      - xcodebuild -create-xcframework -library target/aarch64-apple-ios-sim/release/libglsdk.a -library target/aarch64-apple-ios/release/libglsdk.a -output target/glsdkFFI.xcframework
+      - xcodegen generate --spec build/project.yml --project ./libs/gl-sdk-swift
+      - xcodebuild archive -project libs/gl-sdk-swift/GreenlightBindings.xcodeproj -scheme glsdkFFI -archivePath "./target/ios.xcarchive" -sdk iphoneos -destination "generic/platform=iOS"
+      - xcodebuild archive -project libs/gl-sdk-swift/GreenlightBindings.xcodeproj -scheme glsdkFFI -archivePath "./target/ios_sim.xcarchive" -sdk iphonesimulator -destination "generic/platform=iOS Simulator"
+      - xcodebuild -create-xcframework -framework "./target/ios.xcarchive/Products/Library/Frameworks/glsdkFFI.framework" -framework "./target/ios_sim.xcarchive/Products/Library/Frameworks/glsdkFFI.framework" -output "./target/glsdkFFI.xcframework"
 
   linux-*-*:
     vars:
@@ -53,10 +56,10 @@ tasks:
   ios-sim:
     deps:
       - ios-sim-apple-aarch64
-#      - ios-apple-x86_64
-#   cmds:
-#      - mkdir -p target/lipo-ios-sim/release
-#      - lipo -create target/aarch64-apple-ios-sim/release/libglsdk.a target/x86_64-apple-ios/release/libglsdk.a -output target/lipo-ios-sim/release/libglsdk.a
+      - ios-apple-x86_64
+    cmds:
+      - mkdir -p target/lipo-ios-sim/release
+      - lipo -create target/aarch64-apple-ios-sim/release/libglsdk.a target/x86_64-apple-ios/release/libglsdk.a -output target/lipo-ios-sim/release/libglsdk.a
 
   ios-apple-*:
     vars:

--- a/build/project.yml
+++ b/build/project.yml
@@ -1,0 +1,27 @@
+name: GreenlightBindings
+options:
+  bundleIdPrefix: com.blockstream
+targets:
+  glsdkFFI:
+    type: framework
+    platform: iOS
+    deploymentTarget: "13.0"
+    settings:
+      MACH_O_TYPE: staticlib
+      GENERATE_MASTER_OBJECT_FILE: YES
+      GENERATE_INFOPLIST_FILE: YES
+      STRIP_INSTALLED_PRODUCT: NO
+      BUILD_LIBRARIES_FOR_DISTRIBUTION: YES
+      SKIP_INSTALL: NO
+      DEFINES_MODULE: YES
+      ENABLE_BITCODE: NO
+      # Conditional paths:
+      "LIBRARY_SEARCH_PATHS[sdk=iphoneos*]": "../../target/aarch64-apple-ios/release"
+      "LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]": "../../target/lipo-ios-sim/release"
+    sources:
+      - path: "../target/swift/glsdkFFI.h"
+        headerVisibility: public
+    dependencies:
+      # Link the library name. Xcode will look in the search paths defined above.
+      - framework: libglsdk.a
+        embed: false


### PR DESCRIPTION
1. Add support for legacy x86_64 ios simulator and merge ios-sim libraries into one with `lipo`
2. Apple compliant framework distribution:
- creating swift bindings
- creating a wrapper project with `xcodegen`, instead maintain a full .xcproject
- archiving both platforms
- assembling the final xcframework