### PR TITLE
signer: Use case-insensitive comparison for bolt11 invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the subprojects will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+ - Fixed signer rejecting valid `PreapproveInvoice` requests for uppercase bolt11 invoices by using case-insensitive comparison, matching the bech32 spec (BIP173). ([#698](https://github.com/Blockstream/greenlight/pull/698))
+
 ## [0.3.3]
 
 ### Changed

--- a/libs/gl-client/src/signer/resolve.rs
+++ b/libs/gl-client/src/signer/resolve.rs
@@ -93,16 +93,16 @@ impl Resolver {
                     true
                 }
                 (Message::PreapproveInvoice(l), Request::Pay(r)) => {
-                    l.invstring.0 == r.bolt11.as_bytes()
+                    l.invstring.0.eq_ignore_ascii_case(r.bolt11.as_bytes())
                 }
                 (Message::PreapproveInvoice(l), Request::PreApproveInvoice(r)) => {
                     // Manually calling preapproveinvoice should
                     // always be allowed. The bolt11 string have to
                     // match.
-                    l.invstring.0 == r.bolt11.as_bytes()
+                    l.invstring.0.eq_ignore_ascii_case(r.bolt11.as_bytes())
                 }
                 (Message::PreapproveInvoice(l), Request::TrampolinePay(r)) => {
-                    l.invstring.0 == r.bolt11.as_bytes()
+                    l.invstring.0.eq_ignore_ascii_case(r.bolt11.as_bytes())
                 }
                 (_, _) => false,
             };


### PR DESCRIPTION
## Summary
- BOLT11 invoices use bech32 encoding which is case-insensitive (per BIP173), but the signer resolver was comparing invoice strings byte-for-byte
- Uppercase invoices (e.g. `LNBC1...`) would fail to match their lowercase counterparts, causing the signer to reject valid `PreapproveInvoice` requests
- Fixed all three `PreapproveInvoice` match arms in `resolve.rs` to use `eq_ignore_ascii_case()`

## Test plan
- [x] Verify signer accepts `PreapproveInvoice` for uppercase bolt11 strings
- [x] Verify signer still accepts lowercase bolt11 strings (no regression)
- [x] Verify mixed-case bolt11 strings are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)