### PR TITLE
gl-client/gl-sdk: Harden LNURL-pay against real-world services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "tonic 0.11.0",
  "tracing",
  "uniffi",
+ "url",
 ]
 
 [[package]]

--- a/libs/gl-client/src/lnurl/models.rs
+++ b/libs/gl-client/src/lnurl/models.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 use async_trait::async_trait;
 use log::debug;
 use mockall::automock;
@@ -97,12 +97,27 @@ impl SuccessAction {
     /// `preimage` is the 32-byte payment preimage from the PayResponse.
     /// For Message and Url variants this is a simple conversion; for Aes
     /// it decrypts the ciphertext using the preimage as the AES-256 key.
+    ///
+    /// All payload-shape checks here are required by the LNURL specs:
+    /// - Message.message ≤ 144 chars (LUD-09)
+    /// - Url.description ≤ 144 chars (LUD-09)
+    /// - Aes.description ≤ 144 chars (LUD-10)
+    /// - Aes.ciphertext ≤ 4096 chars (LUD-10)
+    /// - Aes.iv == exactly 24 base64 chars / 16 bytes (LUD-10)
     pub fn process(self, preimage: &[u8]) -> Result<ProcessedSuccessAction> {
         match self {
             SuccessAction::Message { message } => {
+                ensure!(
+                    message.len() <= 144,
+                    "Message success action exceeds 144 chars"
+                );
                 Ok(ProcessedSuccessAction::Message { message })
             }
             SuccessAction::Url { description, url } => {
+                ensure!(
+                    description.len() <= 144,
+                    "Url success action description exceeds 144 chars"
+                );
                 Ok(ProcessedSuccessAction::Url { description, url })
             }
             SuccessAction::Aes {
@@ -110,6 +125,18 @@ impl SuccessAction {
                 ciphertext,
                 iv,
             } => {
+                ensure!(
+                    description.len() <= 144,
+                    "AES success action description exceeds 144 chars"
+                );
+                ensure!(
+                    ciphertext.len() <= 4096,
+                    "AES success action ciphertext exceeds 4096 chars"
+                );
+                ensure!(
+                    iv.len() == 24,
+                    "AES success action IV must be exactly 24 base64 chars"
+                );
                 let plaintext =
                     super::pay::decrypt_aes_success_action(preimage, &ciphertext, &iv)?;
                 Ok(ProcessedSuccessAction::Aes {

--- a/libs/gl-client/src/lnurl/pay/mod.rs
+++ b/libs/gl-client/src/lnurl/pay/mod.rs
@@ -1,7 +1,7 @@
 use super::models::SuccessAction;
 use super::utils::parse_lnurl;
 
-use crate::lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescriptionRef};
+use crate::lightning_invoice::Bolt11Invoice;
 use crate::lnurl::{
     models::{LnUrlHttpClient, PayRequestCallbackResponse, PayRequestResponse},
     utils::parse_invoice,
@@ -10,7 +10,6 @@ use crate::lnurl::{
 use anyhow::{anyhow, ensure, Result};
 use log::debug;
 use reqwest::Url;
-use sha256;
 
 impl PayRequestResponse {
     /// Extract the "text/plain" description from the metadata JSON.
@@ -79,33 +78,45 @@ impl PayRequestResponse {
         amount_msats: u64,
         comment: Option<&str>,
     ) -> Result<(String, Option<SuccessAction>)> {
-        fetch_invoice(http_client, &self.callback, amount_msats, &self.metadata, comment).await
+        fetch_invoice(http_client, &self.callback, amount_msats, comment).await
     }
 }
 
 /// Fetch an invoice from a pay-request callback URL.
 ///
 /// This is the "phase 2" of the two-phase LNURL-pay flow: the caller
-/// already has the callback URL and metadata from the initial
-/// `payRequest` response, and now requests an invoice for a specific
-/// amount.  The returned invoice is validated against the expected
-/// amount and metadata hash before being returned.
+/// already has the callback URL from the initial `payRequest` response,
+/// and now requests an invoice for a specific amount. The returned
+/// invoice is validated to be parseable and match the requested amount.
 pub async fn fetch_invoice<T: LnUrlHttpClient>(
     http_client: &T,
     callback: &str,
     amount_msats: u64,
-    metadata: &str,
     comment: Option<&str>,
 ) -> Result<(String, Option<SuccessAction>)> {
     let callback_url = build_callback_url(callback, amount_msats, comment)?;
-    let callback_response: PayRequestCallbackResponse = http_client
-        .get_pay_request_callback_response(&callback_url)
-        .await?;
+    let raw: serde_json::Value = http_client.get_json(&callback_url).await?;
+
+    if raw.get("status").and_then(|v| v.as_str()) == Some("ERROR") {
+        let reason = raw
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        return Err(anyhow!("{}{}", LNURL_SERVICE_ERROR_PREFIX, reason));
+    }
+
+    let callback_response: PayRequestCallbackResponse = serde_json::from_value(raw)?;
 
     let invoice = parse_invoice(&callback_response.pr)?;
-    validate_invoice(&invoice, amount_msats, metadata)?;
+    validate_invoice(&invoice, amount_msats)?;
     Ok((invoice.to_string(), callback_response.success_action))
 }
+
+/// Prefix used on `fetch_invoice` errors that originate from the LNURL
+/// service returning a `{"status":"ERROR"}` body. Callers can match on
+/// this prefix to distinguish service-side rejections from transport
+/// or parsing failures.
+pub const LNURL_SERVICE_ERROR_PREFIX: &str = "LNURL service error: ";
 
 /// Build a callback URL with amount and optional comment query parameters.
 fn build_callback_url(
@@ -117,17 +128,15 @@ fn build_callback_url(
     url.query_pairs_mut()
         .append_pair("amount", &amount.to_string());
     if let Some(c) = comment {
-        url.query_pairs_mut().append_pair("comment", c);
+        if !c.is_empty() {
+            url.query_pairs_mut().append_pair("comment", c);
+        }
     }
     Ok(url.to_string())
 }
 
-/// Validate a BOLT11 invoice against the expected amount and metadata.
-fn validate_invoice(
-    invoice: &Bolt11Invoice,
-    amount_msats: u64,
-    metadata: &str,
-) -> Result<()> {
+/// Validate a BOLT11 invoice against the user-requested amount.
+fn validate_invoice(invoice: &Bolt11Invoice, amount_msats: u64) -> Result<()> {
     ensure!(
         invoice.amount_milli_satoshis().unwrap_or_default() == amount_msats,
         "Amount found in invoice was not equal to the amount found in the original request\n\
@@ -135,19 +144,6 @@ fn validate_invoice(
         amount_msats,
         invoice.amount_milli_satoshis()
     );
-
-    let description_hash: String = match invoice.description() {
-        Bolt11InvoiceDescriptionRef::Direct(d) => sha256::digest(d.to_string()),
-        Bolt11InvoiceDescriptionRef::Hash(h) => h.0.to_string(),
-    };
-
-    ensure!(
-        description_hash == sha256::digest(metadata),
-        "description_hash {} does not match the hash of the metadata {}",
-        description_hash,
-        sha256::digest(metadata)
-    );
-
     Ok(())
 }
 
@@ -289,10 +285,10 @@ mod tests {
             convert_to_async_return_value(Ok(x))
         });
 
-        mock_http_client.expect_get_pay_request_callback_response().returning(|_url| {
+        mock_http_client.expect_get_json().returning(|_url| {
             let invoice = "lnbc1u1pjv9qrvsp5e5wwexctzp9yklcrzx448c68q2a7kma55cm67ruajjwfkrswnqvqpp55x6mmz8ch6nahrcuxjsjvs23xkgt8eu748nukq463zhjcjk4s65shp5dd6hc533r655wtyz63jpf6ja08srn6rz6cjhwsjuyckrqwanhjtsxqzjccqpjrzjqw6lfdpjecp4d5t0gxk5khkrzfejjxyxtxg5exqsd95py6rhwwh72rpgrgqq3hcqqgqqqqlgqqqqqqgq9q9qxpqysgq95njz4sz6h7r2qh7txnevcrvg0jdsfpe72cecmjfka8mw5nvm7tydd0j34ps2u9q9h6v5u8h3vxs8jqq5fwehdda6a8qmpn93fm290cquhuc6r";
             let callback_response_json = format!("{{\"pr\":\"{}\",\"routes\":[]}}", invoice);
-            let x = serde_json::from_str(&callback_response_json).unwrap();
+            let x: serde_json::Value = serde_json::from_str(&callback_response_json).unwrap();
             convert_to_async_return_value(Ok(x))
         });
 
@@ -324,10 +320,10 @@ mod tests {
             convert_to_async_return_value(Ok(x))
         });
 
-        mock_http_client.expect_get_pay_request_callback_response().returning(|_url| {
+        mock_http_client.expect_get_json().returning(|_url| {
             let invoice = "lnbcrt1u1pj0ypx6sp5hzczugdw9eyw3fcsjkssux7awjlt68vpj7uhmen7sup0hdlrqxaqpp5gp5fm2sn5rua2jlzftkf5h22rxppwgszs7ncm73pmwhvjcttqp3qdy2tddjyar90p6z7urvv95kug3vyq39xarpwf6zqargv5syxmmfde28yctfdc396tpqtv38getcwshkjer9de6xjenfv4ezytpqyfekzar0wd5xjsrrd9cxsetjwp6ku6ewvdhk6gjat5xqyjw5qcqp29qxpqysgqujuf5zavazln2q9gks7nqwdgjypg2qlvv7aqwfmwg7xmjt8hy4hx2ctr5fcspjvmz9x5wvmur8vh6nkynsvateafm73zwg5hkf7xszsqajqwcf";
             let callback_response_json = format!("{{\"pr\":\"{}\",\"routes\":[]}}", invoice);
-            let x = serde_json::from_str(&callback_response_json).unwrap();
+            let x: serde_json::Value = serde_json::from_str(&callback_response_json).unwrap();
             convert_to_async_return_value(Ok(x))
         });
 

--- a/libs/gl-sdk-android/lib/src/androidInstrumentedTest/kotlin/com/blockstream/glsdk/LnurlParseTest.kt
+++ b/libs/gl-sdk-android/lib/src/androidInstrumentedTest/kotlin/com/blockstream/glsdk/LnurlParseTest.kt
@@ -1,0 +1,92 @@
+// Instrumented tests for parse_input() LNURL handling.
+// Covers LNURL bech32 strings, lightning addresses, prefix handling,
+// and error cases. Pure parsing only — no node, no network.
+
+package com.blockstream.glsdk
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LnurlParseTest {
+
+    // LNURL bech32 encoding of https://service.com/lnurl (LUD-01 example).
+    private val lnurlBech32 =
+        "LNURL1DP68GURN8GHJ7CMFWP5X2UNSW4HXKTNRDAKJ7CTSDYHHVVF0D3H82UNV9UCSAXQZE2"
+
+    // ============================================================
+    // LNURL bech32 parsing
+    // ============================================================
+
+    @Test
+    fun parse_lnurl_bech32_uppercase() {
+        val result = parseInput(lnurlBech32)
+        assertTrue(
+            "Expected LnUrl, got $result",
+            result is InputType.LnUrl,
+        )
+    }
+
+    @Test
+    fun parse_lnurl_bech32_lowercase() {
+        val result = parseInput(lnurlBech32.lowercase())
+        assertTrue(
+            "Expected LnUrl, got $result",
+            result is InputType.LnUrl,
+        )
+    }
+
+    @Test
+    fun parse_lnurl_with_lightning_prefix() {
+        val result = parseInput("lightning:$lnurlBech32")
+        assertTrue(
+            "Expected LnUrl, got $result",
+            result is InputType.LnUrl,
+        )
+    }
+
+    @Test(expected = Exception::class)
+    fun parse_invalid_lnurl_bech32_returns_error() {
+        parseInput("LNURL1INVALIDDATA")
+    }
+
+    // ============================================================
+    // Lightning address parsing
+    // ============================================================
+
+    @Test
+    fun parse_lightning_address_simple() {
+        val result = parseInput("user@example.com")
+        assertTrue(
+            "Expected LnUrlAddress, got $result",
+            result is InputType.LnUrlAddress,
+        )
+        assertEquals("user@example.com", (result as InputType.LnUrlAddress).address)
+    }
+
+    @Test
+    fun parse_lightning_address_with_symbols() {
+        val result = parseInput("sat.oshi-99@example.com")
+        assertTrue(
+            "Expected LnUrlAddress, got $result",
+            result is InputType.LnUrlAddress,
+        )
+    }
+
+    @Test(expected = Exception::class)
+    fun parse_lightning_address_no_dot_in_domain_returns_error() {
+        parseInput("user@localhost")
+    }
+
+    @Test(expected = Exception::class)
+    fun parse_lightning_address_empty_local_part_returns_error() {
+        parseInput("@example.com")
+    }
+
+    @Test(expected = Exception::class)
+    fun parse_lightning_address_empty_domain_returns_error() {
+        parseInput("user@")
+    }
+}

--- a/libs/gl-sdk-napi/src/lib.rs
+++ b/libs/gl-sdk-napi/src/lib.rs
@@ -229,6 +229,9 @@ pub struct LnUrlPayRequest {
     /// Amount in millisatoshis (i64 for JS)
     pub amount_msat: i64,
     pub comment: Option<String>,
+    /// When true (the default), a URL success action is rejected if its
+    /// domain differs from the callback's domain.
+    pub validate_success_action_url: Option<bool>,
 }
 
 #[napi(object)]
@@ -250,15 +253,23 @@ pub struct LnUrlErrorData {
     pub reason: String,
 }
 
+#[napi(object)]
+pub struct LnUrlPayErrorData {
+    pub payment_hash: String,
+    pub reason: String,
+}
+
 /// Result of an LNURL-pay operation. Discriminated by `type` field.
 #[napi(object)]
 pub struct LnUrlPayResult {
-    /// "success" or "error"
+    /// "success", "error", or "pay_error"
     pub r#type: String,
     /// Present when type == "success"
     pub success: Option<LnUrlPaySuccessData>,
-    /// Present when type == "error"
+    /// Present when type == "error" (LNURL service rejected the request)
     pub error: Option<LnUrlErrorData>,
+    /// Present when type == "pay_error" (invoice fetched but paying it failed)
+    pub pay_error: Option<LnUrlPayErrorData>,
 }
 
 #[napi(object)]
@@ -1026,6 +1037,7 @@ fn gl_lnurl_pay_request_from_napi(req: LnUrlPayRequest) -> glsdk::LnUrlPayReques
         data: gl_pay_request_data_from_napi(req.data),
         amount_msat: req.amount_msat as u64,
         comment: req.comment,
+        validate_success_action_url: req.validate_success_action_url,
     }
 }
 
@@ -1075,11 +1087,22 @@ fn napi_lnurl_pay_result_from_gl(result: glsdk::LnUrlPayResult) -> LnUrlPayResul
                 success_action: data.success_action.map(napi_success_action_from_gl),
             }),
             error: None,
+            pay_error: None,
         },
         glsdk::LnUrlPayResult::EndpointError { data } => LnUrlPayResult {
             r#type: "error".to_string(),
             success: None,
             error: Some(LnUrlErrorData {
+                reason: data.reason,
+            }),
+            pay_error: None,
+        },
+        glsdk::LnUrlPayResult::PayError { data } => LnUrlPayResult {
+            r#type: "pay_error".to_string(),
+            success: None,
+            error: None,
+            pay_error: Some(LnUrlPayErrorData {
+                payment_hash: data.payment_hash,
                 reason: data.reason,
             }),
         },

--- a/libs/gl-sdk/Cargo.toml
+++ b/libs/gl-sdk/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", features = ["sync"] }
 tonic.workspace = true
 tracing = { version = "0.1.43", features = ["async-await", "log"] }
 uniffi = { version = "0.29.4" }
+url = "2"
 
 [build-dependencies]
 uniffi = { version = "0.29.4", features = [ "build" ] }

--- a/libs/gl-sdk/src/lib.rs
+++ b/libs/gl-sdk/src/lib.rs
@@ -108,7 +108,7 @@ fn schedule_node(
             .map_err(|e| Error::Other(e.to_string()))?;
 
     let handle = signer::Handle::spawn(authenticated_signer);
-    let node = node::Node::with_signer(credentials, handle)?;
+    let node = node::Node::with_signer(credentials, handle, network)?;
     Ok(Arc::new(node))
 }
 
@@ -198,7 +198,7 @@ pub fn connect(
             .map_err(|e| Error::Other(e.to_string()))?;
 
     let handle = signer::Handle::spawn(authenticated_signer);
-    let node = node::Node::with_signer(creds, handle)?;
+    let node = node::Node::with_signer(creds, handle, network)?;
     Ok(Arc::new(node))
 }
 

--- a/libs/gl-sdk/src/lnurl.rs
+++ b/libs/gl-sdk/src/lnurl.rs
@@ -73,6 +73,15 @@ pub struct LnUrlPayRequest {
     pub amount_msat: u64,
     /// Optional comment to send with the payment.
     pub comment: Option<String>,
+    /// When true (the default), a URL success action is rejected if its
+    /// domain differs from the callback's domain.
+    ///
+    /// This is a wallet-side safety convention, not a LUD-09 requirement:
+    /// LUD-09 does not mandate same-domain URLs, but a divergent domain
+    /// can be used to phish users, so the SDK rejects it by default.
+    /// Set to `Some(false)` only if you have a specific reason to trust
+    /// cross-domain success-action URLs from this service.
+    pub validate_success_action_url: Option<bool>,
 }
 
 /// Request to execute an LNURL-withdraw flow.
@@ -95,8 +104,10 @@ pub struct LnUrlWithdrawRequest {
 pub enum LnUrlPayResult {
     /// Payment succeeded.
     EndpointSuccess { data: LnUrlPaySuccessData },
-    /// The LNURL service returned an error.
+    /// The LNURL service returned an error before the invoice was paid.
     EndpointError { data: LnUrlErrorData },
+    /// The invoice was fetched successfully but paying it failed.
+    PayError { data: LnUrlPayErrorData },
 }
 
 /// Successful LNURL-pay result data.
@@ -106,6 +117,15 @@ pub struct LnUrlPaySuccessData {
     pub payment_preimage: String,
     /// Optional success action from the service (LUD-09).
     pub success_action: Option<SuccessActionProcessed>,
+}
+
+/// Details of a failed LNURL-pay attempt on the pay phase.
+#[derive(Clone, uniffi::Record)]
+pub struct LnUrlPayErrorData {
+    /// Hex-encoded payment hash of the invoice the service returned.
+    pub payment_hash: String,
+    /// Human-readable reason the pay attempt failed.
+    pub reason: String,
 }
 
 /// Result of an LNURL-withdraw operation.

--- a/libs/gl-sdk/src/node.rs
+++ b/libs/gl-sdk/src/node.rs
@@ -19,6 +19,7 @@ pub struct Node {
     stored_credentials: Option<Credentials>,
     signer_handle: Option<Handle>,
     disconnected: AtomicBool,
+    network: gl_client::bitcoin::Network,
 }
 
 #[uniffi::export]
@@ -41,6 +42,7 @@ impl Node {
             stored_credentials: Some(credentials.clone()),
             signer_handle: None,
             disconnected: AtomicBool::new(false),
+            network: gl_client::bitcoin::Network::Bitcoin,
         })
     }
 
@@ -513,37 +515,80 @@ impl Node {
         request: crate::lnurl::LnUrlPayRequest,
     ) -> Result<crate::lnurl::LnUrlPayResult, Error> {
         self.check_connected()?;
+        validate_lnurl_pay_input(&request)?;
 
         let http_client = gl_client::lnurl::models::LnUrlHttpClearnetClient::new();
 
         // Phase 1: Get invoice from service callback
         let comment = request.comment.as_deref();
-        let (invoice_str, success_action) = exec(
+        let (invoice_str, success_action) = match exec(
             gl_client::lnurl::pay::fetch_invoice(
                 &http_client,
                 &request.data.callback,
                 request.amount_msat,
-                &request.data.metadata,
                 comment,
             ),
-        )
-        .map_err(|e| Error::Other(e.to_string()))?;
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                let msg = e.to_string();
+                let reason = msg
+                    .strip_prefix(gl_client::lnurl::pay::LNURL_SERVICE_ERROR_PREFIX)
+                    .unwrap_or(&msg)
+                    .to_string();
+                return Ok(crate::lnurl::LnUrlPayResult::EndpointError {
+                    data: crate::lnurl::LnUrlErrorData { reason },
+                });
+            }
+        };
+
+        if let Some(reason) = invoice_network_mismatch(&invoice_str, self.network) {
+            return Ok(crate::lnurl::LnUrlPayResult::EndpointError {
+                data: crate::lnurl::LnUrlErrorData { reason },
+            });
+        }
 
         // Phase 2: Pay the invoice
         let mut cln_client = exec(self.get_cln_client())?.clone();
-        let pay_response = exec(cln_client.pay(clnpb::PayRequest {
-            bolt11: invoice_str,
+        let pay_response = match exec(cln_client.pay(clnpb::PayRequest {
+            bolt11: invoice_str.clone(),
             ..Default::default()
-        }))
-        .map_err(|e| Error::Rpc(e.to_string()))?
-        .into_inner();
+        })) {
+            Ok(r) => r.into_inner(),
+            Err(e) => {
+                let payment_hash = invoice_str
+                    .parse::<Bolt11Invoice>()
+                    .ok()
+                    .map(|inv| inv.payment_hash().to_string())
+                    .unwrap_or_default();
+                return Ok(crate::lnurl::LnUrlPayResult::PayError {
+                    data: crate::lnurl::LnUrlPayErrorData {
+                        payment_hash,
+                        reason: e.to_string(),
+                    },
+                });
+            }
+        };
 
         // Phase 3: Process success action if present
+        let validate_url = request.validate_success_action_url.unwrap_or(true);
         let processed_action = match success_action {
             Some(action) => {
                 let processed = action
                     .process(&pay_response.payment_preimage)
                     .map_err(|e| Error::Other(e.to_string()))?;
+                if validate_url {
+                    if let gl_client::lnurl::models::ProcessedSuccessAction::Url {
+                        url, ..
+                    } = &processed
+                    {
+                        if let Some(reason) =
+                            url_action_domain_mismatch(&request.data.callback, url)
+                        {
+                            return Err(Error::Other(reason));
+                        }
+                    }
+                }
                 Some(processed.into())
             }
             None => None,
@@ -608,6 +653,83 @@ impl Node {
     }
 }
 
+/// Returns a human-readable reason if the invoice's BOLT-11 currency
+/// prefix does not match the node's configured network.
+///
+/// Not a LUD-06 requirement; this is a wallet-side safety check that
+/// prevents attempting to pay e.g. a testnet invoice from a mainnet
+/// wallet. The payment would fail at the node layer regardless, but
+/// this surfaces a clean error earlier.
+fn invoice_network_mismatch(
+    invoice_str: &str,
+    node_network: gl_client::bitcoin::Network,
+) -> Option<String> {
+    use lightning_invoice::Currency;
+    let invoice = invoice_str.parse::<Bolt11Invoice>().ok()?;
+    let expected = match node_network {
+        gl_client::bitcoin::Network::Bitcoin => Currency::Bitcoin,
+        gl_client::bitcoin::Network::Testnet => Currency::BitcoinTestnet,
+        gl_client::bitcoin::Network::Signet => Currency::Signet,
+        gl_client::bitcoin::Network::Regtest => Currency::Regtest,
+        _ => return None,
+    };
+    if invoice.currency() == expected {
+        None
+    } else {
+        Some(format!(
+            "invoice is for {:?}, but this node is on {:?}",
+            invoice.currency(),
+            node_network
+        ))
+    }
+}
+
+fn url_action_domain_mismatch(callback_url: &str, action_url: &str) -> Option<String> {
+    let cb = url::Url::parse(callback_url).ok()?;
+    let action = url::Url::parse(action_url).ok()?;
+    let cb_domain = cb.domain()?;
+    let action_domain = action.domain()?;
+    if cb_domain == action_domain {
+        None
+    } else {
+        Some(format!(
+            "success action URL domain ({}) does not match the callback domain ({})",
+            action_domain, cb_domain
+        ))
+    }
+}
+
+fn validate_lnurl_pay_input(request: &crate::lnurl::LnUrlPayRequest) -> Result<(), Error> {
+    let data = &request.data;
+    if request.amount_msat < data.min_sendable {
+        return Err(Error::Other(format!(
+            "amount_msat {} is below the service's min_sendable ({})",
+            request.amount_msat, data.min_sendable
+        )));
+    }
+    if request.amount_msat > data.max_sendable {
+        return Err(Error::Other(format!(
+            "amount_msat {} is above the service's max_sendable ({})",
+            request.amount_msat, data.max_sendable
+        )));
+    }
+    if let Some(comment) = request.comment.as_deref() {
+        if data.comment_allowed == 0 && !comment.is_empty() {
+            return Err(Error::Other(
+                "this LNURL service does not accept comments".to_string(),
+            ));
+        }
+        if (comment.len() as u64) > data.comment_allowed {
+            return Err(Error::Other(format!(
+                "comment length {} exceeds the service's comment_allowed ({})",
+                comment.len(),
+                data.comment_allowed
+            )));
+        }
+    }
+    Ok(())
+}
+
 // Not exported through uniffi
 impl Node {
     fn check_connected(&self) -> Result<(), Error> {
@@ -622,6 +744,7 @@ impl Node {
     pub(crate) fn with_signer(
         credentials: Credentials,
         handle: Handle,
+        network: gl_client::bitcoin::Network,
     ) -> Result<Self, Error> {
         let node_id = credentials
             .inner
@@ -639,6 +762,7 @@ impl Node {
             stored_credentials: Some(credentials),
             signer_handle: Some(handle),
             disconnected: AtomicBool::new(false),
+            network,
         })
     }
 


### PR DESCRIPTION
Gaps surfaced when paying stacker.news exposed several mismatches between the current implementation and what wallets need in practice. Changes align gl-sdk's LNURL-pay surface with the LUD specs and with what Breez SDK does for the convention-level gaps:

- Parse LUD-06 service errors: callback responses with {"status":"ERROR"} are now recognised and surfaced as LnUrlPayResult::EndpointError with the service's reason, instead of failing JSON deserialization.
- Add LnUrlPayResult::PayError { payment_hash, reason } so CLN pay-side failures return structured results rather than Error::Rpc.
- Pre-flight amount/comment validation in gl-sdk::lnurl_pay to reject out-of-bounds requests before any network round-trip.
- Drop the description_hash == SHA256(metadata) check that rejected compliant-enough services whose metadata embeds per-request data.
- Skip the empty `comment` query param in the callback URL when the caller passes None or an empty string.
- Enforce LUD-09/10 bounds on SuccessAction payloads (Message/Url description ≤ 144, AES description ≤ 144, ciphertext ≤ 4096, IV exactly 24 chars) before any AES decryption.
- Validate the invoice's BOLT-11 currency prefix against the node's configured network; thread `network` through Node::with_signer so the check has something to compare against.
- Validate that a URL success action's domain matches the callback domain, with an opt-out via LnUrlPayRequest.validate_success_action_url (defaults to true).