### PR TITLE
gl-sdk: Add node_id() getter on Credentials

### DIFF
--- a/libs/gl-sdk/src/credentials.rs
+++ b/libs/gl-sdk/src/credentials.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use gl_client::credentials::Device as DeviceCredentials;
+use gl_client::credentials::{Device as DeviceCredentials, NodeIdProvider};
 
 /// A developer certificate obtained from the Greenlight Developer
 /// Console (GDC). When provided to a `Scheduler` via
@@ -47,5 +47,9 @@ impl Credentials {
 
     pub fn save(&self) -> Result<Vec<u8>, Error> {
         Ok(self.inner.to_bytes())
+    }
+
+    pub fn node_id(&self) -> Result<Vec<u8>, Error> {
+        self.inner.node_id().map_err(|e| Error::Other(e.to_string()))
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `node_id()` getter on `gl-sdk`'s `Credentials` struct, delegating to the inner `gl_client::credentials::Device`'s `NodeIdProvider` implementation.
- Mirrors the existing `Signer::node_id()` getter so consumers of the UniFFI bindings can retrieve the node id directly from persisted credentials, without spinning up a signer.

Closes #644

## Test plan
- [x] `cargo build -p gl-sdk` succeeds
- [x] Verify the method is exposed across UniFFI language bindings (Python/Kotlin/Swift/Ruby) after regenerating

🤖 Generated with [Claude Code](https://claude.com/claude-code)