### PR TITLE
feat(gl-sdk): add LogListener for foreign-binding log capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "gl-client",
  "hex",
  "lightning-invoice",
+ "log",
  "once_cell",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,8 @@ dependencies = [
  "hex",
  "lightning-invoice",
  "once_cell",
+ "serde",
+ "serde_json",
  "thiserror 2.0.17",
  "tokio",
  "tonic 0.11.0",

--- a/libs/gl-sdk-android/lib/src/androidInstrumentedTest/kotlin/com/blockstream/glsdk/LoggingTest.kt
+++ b/libs/gl-sdk-android/lib/src/androidInstrumentedTest/kotlin/com/blockstream/glsdk/LoggingTest.kt
@@ -1,0 +1,73 @@
+// Instrumented tests for the SDK logging framework.
+//
+// `setLogger` installs a process-wide logger — only one install
+// succeeds per process. A `@Before` step installs a shared capturing
+// listener; subsequent tests inspect it or call `setLogLevel` without
+// re-installing.
+
+package com.blockstream.glsdk
+
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.*
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.ConcurrentLinkedQueue
+
+@RunWith(AndroidJUnit4::class)
+class LoggingTest {
+
+    companion object {
+        private val captured = ConcurrentLinkedQueue<LogEntry>()
+
+        @BeforeClass
+        @JvmStatic
+        fun installLogger() {
+            val listener = object : LogListener {
+                override fun onLog(entry: LogEntry) {
+                    captured.add(entry)
+                    Log.d("glsdk", "[${entry.level}] ${entry.target}: ${entry.message}")
+                }
+            }
+            try {
+                setLogger(LogLevel.TRACE, listener)
+            } catch (e: Exception) {
+                // Already installed by a prior test class in the same
+                // process — expected when multiple test classes run.
+            }
+        }
+    }
+
+    @Test
+    fun set_log_level_does_not_throw() {
+        setLogLevel(LogLevel.WARN)
+        setLogLevel(LogLevel.TRACE)
+    }
+
+    @Test
+    fun listener_receives_logs_during_sdk_activity() {
+        captured.clear()
+        setLogLevel(LogLevel.TRACE)
+
+        val config = Config()
+        val mnemonic = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong"
+        try {
+            registerOrRecover(mnemonic, null, config)
+        } catch (_: Exception) {
+            // May fail on network / credentials — we only care that logs flowed.
+        }
+
+        val entries = captured.toList()
+        Log.d("glsdk", "Captured ${entries.size} log entries")
+        assertTrue(
+            "Expected at least one log entry from gl-client during register_or_recover",
+            entries.isNotEmpty(),
+        )
+        // Every entry should have a non-empty target and message
+        for (entry in entries) {
+            assertFalse("empty target in $entry", entry.target.isEmpty())
+            assertNotNull(entry.message)
+        }
+    }
+}

--- a/libs/gl-sdk/Cargo.toml
+++ b/libs/gl-sdk/Cargo.toml
@@ -17,6 +17,8 @@ gl-client = { version = "0.4.0", path = "../gl-client" }
 hex = "0.4"
 lightning-invoice = "0.33"
 once_cell = "1.21.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2.0.17"
 tokio = { version = "1", features = ["sync"] }
 tonic.workspace = true

--- a/libs/gl-sdk/Cargo.toml
+++ b/libs/gl-sdk/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1"
 bip39 = "2.2.0"
 gl-client = { version = "0.4.0", path = "../gl-client" }
 hex = "0.4"
+log = "0.4"
 lightning-invoice = "0.33"
 once_cell = "1.21.3"
 serde = { version = "1", features = ["derive"] }

--- a/libs/gl-sdk/glsdk/glsdk.py
+++ b/libs/gl-sdk/glsdk/glsdk.py
@@ -474,6 +474,8 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_config_with_network() != 35643:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_glsdk_checksum_method_credentials_node_id() != 16312:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_credentials_save() != 26677:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_handle_stop() != 36432:
@@ -481,6 +483,8 @@ def _uniffi_check_api_checksums(lib):
     if lib.uniffi_glsdk_checksum_method_node_credentials() != 39165:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_node_disconnect() != 43626:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_glsdk_checksum_method_node_generate_diagnostic_data() != 41140:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_node_get_info() != 39460:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -685,6 +689,11 @@ _UniffiLib.uniffi_glsdk_fn_constructor_credentials_load.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_glsdk_fn_constructor_credentials_load.restype = ctypes.c_void_p
+_UniffiLib.uniffi_glsdk_fn_method_credentials_node_id.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_glsdk_fn_method_credentials_node_id.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_glsdk_fn_method_credentials_save.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -746,6 +755,11 @@ _UniffiLib.uniffi_glsdk_fn_method_node_disconnect.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_glsdk_fn_method_node_disconnect.restype = None
+_UniffiLib.uniffi_glsdk_fn_method_node_generate_diagnostic_data.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_glsdk_fn_method_node_generate_diagnostic_data.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_glsdk_fn_method_node_get_info.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -1243,6 +1257,9 @@ _UniffiLib.uniffi_glsdk_checksum_method_config_with_developer_cert.restype = cty
 _UniffiLib.uniffi_glsdk_checksum_method_config_with_network.argtypes = (
 )
 _UniffiLib.uniffi_glsdk_checksum_method_config_with_network.restype = ctypes.c_uint16
+_UniffiLib.uniffi_glsdk_checksum_method_credentials_node_id.argtypes = (
+)
+_UniffiLib.uniffi_glsdk_checksum_method_credentials_node_id.restype = ctypes.c_uint16
 _UniffiLib.uniffi_glsdk_checksum_method_credentials_save.argtypes = (
 )
 _UniffiLib.uniffi_glsdk_checksum_method_credentials_save.restype = ctypes.c_uint16
@@ -1255,6 +1272,9 @@ _UniffiLib.uniffi_glsdk_checksum_method_node_credentials.restype = ctypes.c_uint
 _UniffiLib.uniffi_glsdk_checksum_method_node_disconnect.argtypes = (
 )
 _UniffiLib.uniffi_glsdk_checksum_method_node_disconnect.restype = ctypes.c_uint16
+_UniffiLib.uniffi_glsdk_checksum_method_node_generate_diagnostic_data.argtypes = (
+)
+_UniffiLib.uniffi_glsdk_checksum_method_node_generate_diagnostic_data.restype = ctypes.c_uint16
 _UniffiLib.uniffi_glsdk_checksum_method_node_get_info.argtypes = (
 )
 _UniffiLib.uniffi_glsdk_checksum_method_node_get_info.restype = ctypes.c_uint16
@@ -2884,12 +2904,23 @@ class Payment:
     bolt11: "typing.Optional[str]"
     preimage: "typing.Optional[str]"
     """
-    Payment preimage as lowercase hex (64 chars), when the payment is known.
+    Payment preimage as lowercase hex (64 chars), when known.
     """
 
     destination: "typing.Optional[str]"
     """
-    Counterparty node pubkey as lowercase hex (66 chars), when known.
+    Pubkey of the counterparty in the payment, as lowercase hex
+    (66 chars).
+
+    For `PaymentType::Sent`: the recipient node we paid (when CLN
+    reports it).
+
+    For `PaymentType::Received`: always `None`. Lightning's privacy
+    model does not reveal the sender's pubkey to the recipient — the
+    HTLC arrives via one of our channel peers, but that peer is
+    usually just a router, not the original payer. The only pubkey
+    derivable from a paid invoice is the *payee* (i.e. our own
+    node), which is uninteresting to display per-row.
     """
 
     def __init__(self, *, id: "str", payment_type: "PaymentType", payment_time: "int", amount_msat: "int", fee_msat: "int", status: "PaymentStatus", description: "typing.Optional[str]", bolt11: "typing.Optional[str]", preimage: "typing.Optional[str]", destination: "typing.Optional[str]"):
@@ -4844,6 +4875,8 @@ class CredentialsProtocol(typing.Protocol):
     background.
     """
 
+    def node_id(self, ):
+        raise NotImplementedError
     def save(self, ):
         raise NotImplementedError
 # Credentials is a Rust-only trait - it's a wrapper around a Rust implementation.
@@ -4886,6 +4919,15 @@ class Credentials():
         pointer = _uniffi_rust_call_with_error(_UniffiConverterTypeError,_UniffiLib.uniffi_glsdk_fn_constructor_credentials_load,
         _UniffiConverterBytes.lower(raw))
         return cls._make_instance_(pointer)
+
+
+
+    def node_id(self, ) -> "bytes":
+        return _UniffiConverterBytes.lift(
+            _uniffi_rust_call_with_error(_UniffiConverterTypeError,_UniffiLib.uniffi_glsdk_fn_method_credentials_node_id,self._uniffi_clone_pointer(),)
+        )
+
+
 
 
 
@@ -5112,6 +5154,19 @@ class NodeProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
+    def generate_diagnostic_data(self, ):
+        """
+        Collect a diagnostic snapshot of the node and SDK state.
+
+        Returns a pretty-printed JSON string with shape:
+        `{ "timestamp": <unix-secs>, "node": { ... }, "sdk": { "version": ..., "node_state": ... } }`.
+        The `node` object contains one entry per CLN RPC (`getinfo`,
+        `listpeerchannels`, `listfunds`, `listpays`, `listinvoices`); each
+        value is the serialized response, or `{ "error": "..." }` if that
+        RPC failed. Intended for support tickets.
+        """
+
+        raise NotImplementedError
     def get_info(self, ):
         """
         Get information about the node.
@@ -5301,6 +5356,26 @@ class Node():
 
         _uniffi_rust_call_with_error(_UniffiConverterTypeError,_UniffiLib.uniffi_glsdk_fn_method_node_disconnect,self._uniffi_clone_pointer(),)
 
+
+
+
+
+
+    def generate_diagnostic_data(self, ) -> "str":
+        """
+        Collect a diagnostic snapshot of the node and SDK state.
+
+        Returns a pretty-printed JSON string with shape:
+        `{ "timestamp": <unix-secs>, "node": { ... }, "sdk": { "version": ..., "node_state": ... } }`.
+        The `node` object contains one entry per CLN RPC (`getinfo`,
+        `listpeerchannels`, `listfunds`, `listpays`, `listinvoices`); each
+        value is the serialized response, or `{ "error": "..." }` if that
+        RPC failed. Intended for support tickets.
+        """
+
+        return _UniffiConverterString.lift(
+            _uniffi_rust_call_with_error(_UniffiConverterTypeError,_UniffiLib.uniffi_glsdk_fn_method_node_generate_diagnostic_data,self._uniffi_clone_pointer(),)
+        )
 
 
 

--- a/libs/gl-sdk/glsdk/glsdk.py
+++ b/libs/gl-sdk/glsdk/glsdk.py
@@ -470,6 +470,10 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_func_register_or_recover() != 65070:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_glsdk_checksum_func_set_log_level() != 52328:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_glsdk_checksum_func_set_logger() != 10523:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_config_with_developer_cert() != 64194:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_config_with_network() != 35643:
@@ -484,7 +488,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_node_disconnect() != 43626:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_glsdk_checksum_method_node_generate_diagnostic_data() != 41140:
+    if lib.uniffi_glsdk_checksum_method_node_generate_diagnostic_data() != 10944:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_method_node_get_info() != 39460:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -541,6 +545,8 @@ def _uniffi_check_api_checksums(lib):
     if lib.uniffi_glsdk_checksum_constructor_signer_new() != 62159:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_glsdk_checksum_constructor_signer_new_from_seed() != 6776:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_glsdk_checksum_method_loglistener_on_log() != 34844:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
 
 # A ctypes library to expose the extern-C FFI definitions.
@@ -648,6 +654,14 @@ class _UniffiForeignFutureStructVoid(ctypes.Structure):
     ]
 _UNIFFI_FOREIGN_FUTURE_COMPLETE_VOID = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiForeignFutureStructVoid,
 )
+_UNIFFI_CALLBACK_INTERFACE_LOG_LISTENER_METHOD0 = ctypes.CFUNCTYPE(None,ctypes.c_uint64,_UniffiRustBuffer,ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+class _UniffiVTableCallbackInterfaceLogListener(ctypes.Structure):
+    _fields_ = [
+        ("on_log", _UNIFFI_CALLBACK_INTERFACE_LOG_LISTENER_METHOD0),
+        ("uniffi_free", _UNIFFI_CALLBACK_INTERFACE_FREE),
+    ]
 _UniffiLib.uniffi_glsdk_fn_clone_config.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -936,6 +950,10 @@ _UniffiLib.uniffi_glsdk_fn_method_signer_start.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_glsdk_fn_method_signer_start.restype = ctypes.c_void_p
+_UniffiLib.uniffi_glsdk_fn_init_callback_vtable_loglistener.argtypes = (
+    ctypes.POINTER(_UniffiVTableCallbackInterfaceLogListener),
+)
+_UniffiLib.uniffi_glsdk_fn_init_callback_vtable_loglistener.restype = None
 _UniffiLib.uniffi_glsdk_fn_func_connect.argtypes = (
     _UniffiRustBuffer,
     _UniffiRustBuffer,
@@ -968,6 +986,17 @@ _UniffiLib.uniffi_glsdk_fn_func_register_or_recover.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_glsdk_fn_func_register_or_recover.restype = ctypes.c_void_p
+_UniffiLib.uniffi_glsdk_fn_func_set_log_level.argtypes = (
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_glsdk_fn_func_set_log_level.restype = None
+_UniffiLib.uniffi_glsdk_fn_func_set_logger.argtypes = (
+    _UniffiRustBuffer,
+    ctypes.c_uint64,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_glsdk_fn_func_set_logger.restype = None
 _UniffiLib.ffi_glsdk_rustbuffer_alloc.argtypes = (
     ctypes.c_uint64,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -1251,6 +1280,12 @@ _UniffiLib.uniffi_glsdk_checksum_func_register.restype = ctypes.c_uint16
 _UniffiLib.uniffi_glsdk_checksum_func_register_or_recover.argtypes = (
 )
 _UniffiLib.uniffi_glsdk_checksum_func_register_or_recover.restype = ctypes.c_uint16
+_UniffiLib.uniffi_glsdk_checksum_func_set_log_level.argtypes = (
+)
+_UniffiLib.uniffi_glsdk_checksum_func_set_log_level.restype = ctypes.c_uint16
+_UniffiLib.uniffi_glsdk_checksum_func_set_logger.argtypes = (
+)
+_UniffiLib.uniffi_glsdk_checksum_func_set_logger.restype = ctypes.c_uint16
 _UniffiLib.uniffi_glsdk_checksum_method_config_with_developer_cert.argtypes = (
 )
 _UniffiLib.uniffi_glsdk_checksum_method_config_with_developer_cert.restype = ctypes.c_uint16
@@ -1359,6 +1394,9 @@ _UniffiLib.uniffi_glsdk_checksum_constructor_signer_new.restype = ctypes.c_uint1
 _UniffiLib.uniffi_glsdk_checksum_constructor_signer_new_from_seed.argtypes = (
 )
 _UniffiLib.uniffi_glsdk_checksum_constructor_signer_new_from_seed.restype = ctypes.c_uint16
+_UniffiLib.uniffi_glsdk_checksum_method_loglistener_on_log.argtypes = (
+)
+_UniffiLib.uniffi_glsdk_checksum_method_loglistener_on_log.restype = ctypes.c_uint16
 _UniffiLib.ffi_glsdk_uniffi_contract_version.argtypes = (
 )
 _UniffiLib.ffi_glsdk_uniffi_contract_version.restype = ctypes.c_uint32
@@ -1367,7 +1405,38 @@ _uniffi_check_contract_api_version(_UniffiLib)
 # _uniffi_check_api_checksums(_UniffiLib)
 
 # Public interface members begin here.
+# Magic number for the Rust proxy to call using the same mechanism as every other method,
+# to free the callback once it's dropped by Rust.
+_UNIFFI_IDX_CALLBACK_FREE = 0
+# Return codes for callback calls
+_UNIFFI_CALLBACK_SUCCESS = 0
+_UNIFFI_CALLBACK_ERROR = 1
+_UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
 
+class _UniffiCallbackInterfaceFfiConverter:
+    _handle_map = _UniffiHandleMap()
+
+    @classmethod
+    def lift(cls, handle):
+        return cls._handle_map.get(handle)
+
+    @classmethod
+    def read(cls, buf):
+        handle = buf.read_u64()
+        cls.lift(handle)
+
+    @classmethod
+    def check_lower(cls, cb):
+        pass
+
+    @classmethod
+    def lower(cls, cb):
+        handle = cls._handle_map.insert(cb)
+        return handle
+
+    @classmethod
+    def write(cls, cb, buf):
+        buf.write_u64(cls.lower(cb))
 
 class _UniffiConverterUInt32(_UniffiConverterPrimitiveInt):
     CLASS_NAME = "u32"
@@ -2215,6 +2284,79 @@ class _UniffiConverterTypeListPeersResponse(_UniffiConverterRustBuffer):
     @staticmethod
     def write(value, buf):
         _UniffiConverterSequenceTypePeer.write(value.peers, buf)
+
+
+class LogEntry:
+    """
+    A single log message from the SDK.
+    """
+
+    level: "LogLevel"
+    message: "str"
+    target: "str"
+    """
+    The module that produced this log (e.g. "gl_client::scheduler").
+    """
+
+    file: "typing.Optional[str]"
+    """
+    Source file path, if the log macro recorded one.
+    """
+
+    line: "typing.Optional[int]"
+    """
+    Source line number, if the log macro recorded one.
+    """
+
+    def __init__(self, *, level: "LogLevel", message: "str", target: "str", file: "typing.Optional[str]", line: "typing.Optional[int]"):
+        self.level = level
+        self.message = message
+        self.target = target
+        self.file = file
+        self.line = line
+
+    def __str__(self):
+        return "LogEntry(level={}, message={}, target={}, file={}, line={})".format(self.level, self.message, self.target, self.file, self.line)
+
+    def __eq__(self, other):
+        if self.level != other.level:
+            return False
+        if self.message != other.message:
+            return False
+        if self.target != other.target:
+            return False
+        if self.file != other.file:
+            return False
+        if self.line != other.line:
+            return False
+        return True
+
+class _UniffiConverterTypeLogEntry(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return LogEntry(
+            level=_UniffiConverterTypeLogLevel.read(buf),
+            message=_UniffiConverterString.read(buf),
+            target=_UniffiConverterString.read(buf),
+            file=_UniffiConverterOptionalString.read(buf),
+            line=_UniffiConverterOptionalUInt32.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterTypeLogLevel.check_lower(value.level)
+        _UniffiConverterString.check_lower(value.message)
+        _UniffiConverterString.check_lower(value.target)
+        _UniffiConverterOptionalString.check_lower(value.file)
+        _UniffiConverterOptionalUInt32.check_lower(value.line)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterTypeLogLevel.write(value.level, buf)
+        _UniffiConverterString.write(value.message, buf)
+        _UniffiConverterString.write(value.target, buf)
+        _UniffiConverterOptionalString.write(value.file, buf)
+        _UniffiConverterOptionalUInt32.write(value.line, buf)
 
 
 class NodeState:
@@ -3904,6 +4046,72 @@ class _UniffiConverterTypeListIndex(_UniffiConverterRustBuffer):
 
 
 
+class LogLevel(enum.Enum):
+    """
+    Log level for filtering messages.
+    """
+
+    ERROR = 0
+    
+    WARN = 1
+    
+    INFO = 2
+    
+    DEBUG = 3
+    
+    TRACE = 4
+    
+
+
+class _UniffiConverterTypeLogLevel(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        variant = buf.read_i32()
+        if variant == 1:
+            return LogLevel.ERROR
+        if variant == 2:
+            return LogLevel.WARN
+        if variant == 3:
+            return LogLevel.INFO
+        if variant == 4:
+            return LogLevel.DEBUG
+        if variant == 5:
+            return LogLevel.TRACE
+        raise InternalError("Raw enum value doesn't match any cases")
+
+    @staticmethod
+    def check_lower(value):
+        if value == LogLevel.ERROR:
+            return
+        if value == LogLevel.WARN:
+            return
+        if value == LogLevel.INFO:
+            return
+        if value == LogLevel.DEBUG:
+            return
+        if value == LogLevel.TRACE:
+            return
+        raise ValueError(value)
+
+    @staticmethod
+    def write(value, buf):
+        if value == LogLevel.ERROR:
+            buf.write_i32(1)
+        if value == LogLevel.WARN:
+            buf.write_i32(2)
+        if value == LogLevel.INFO:
+            buf.write_i32(3)
+        if value == LogLevel.DEBUG:
+            buf.write_i32(4)
+        if value == LogLevel.TRACE:
+            buf.write_i32(5)
+
+
+
+
+
+
+
 class Network(enum.Enum):
     BITCOIN = 0
     
@@ -4265,6 +4473,64 @@ class _UniffiConverterTypePaymentTypeFilter(_UniffiConverterRustBuffer):
             buf.write_i32(2)
 
 
+
+
+
+
+class LogListener(typing.Protocol):
+    """
+    Callback interface for receiving log messages.
+
+    `on_log` is invoked on the thread that emitted the log — which can
+    be any tokio worker or background thread inside the SDK. Keep the
+    implementation cheap and non-blocking; if you need UI updates,
+    hand the entry off to your app's main thread.
+    """
+
+    def on_log(self, entry: "LogEntry"):
+        raise NotImplementedError
+
+
+# Put all the bits inside a class to keep the top-level namespace clean
+class _UniffiTraitImplLogListener:
+    # For each method, generate a callback function to pass to Rust
+
+    @_UNIFFI_CALLBACK_INTERFACE_LOG_LISTENER_METHOD0
+    def on_log(
+            uniffi_handle,
+            entry,
+            uniffi_out_return,
+            uniffi_call_status_ptr,
+        ):
+        uniffi_obj = _UniffiConverterTypeLogListener._handle_map.get(uniffi_handle)
+        def make_call():
+            args = (_UniffiConverterTypeLogEntry.lift(entry), )
+            method = uniffi_obj.on_log
+            return method(*args)
+
+        
+        write_return_value = lambda v: None
+        _uniffi_trait_interface_call(
+                uniffi_call_status_ptr.contents,
+                make_call,
+                write_return_value,
+        )
+
+    @_UNIFFI_CALLBACK_INTERFACE_FREE
+    def _uniffi_free(uniffi_handle):
+        _UniffiConverterTypeLogListener._handle_map.remove(uniffi_handle)
+
+    # Generate the FFI VTable.  This has a field for each callback interface method.
+    _uniffi_vtable = _UniffiVTableCallbackInterfaceLogListener(
+        on_log,
+        _uniffi_free
+    )
+    # Send Rust a pointer to the VTable.  Note: this means we need to keep the struct alive forever,
+    # or else bad things will happen when Rust tries to access it.
+    _UniffiLib.uniffi_glsdk_fn_init_callback_vtable_loglistener(ctypes.byref(_uniffi_vtable))
+
+# The _UniffiConverter which transforms the Callbacks in to Handles to pass to Rust.
+_UniffiConverterTypeLogListener = _UniffiCallbackInterfaceFfiConverter()
 
 
 
@@ -5161,9 +5427,11 @@ class NodeProtocol(typing.Protocol):
         Returns a pretty-printed JSON string with shape:
         `{ "timestamp": <unix-secs>, "node": { ... }, "sdk": { "version": ..., "node_state": ... } }`.
         The `node` object contains one entry per CLN RPC (`getinfo`,
-        `listpeerchannels`, `listfunds`, `listpays`, `listinvoices`); each
-        value is the serialized response, or `{ "error": "..." }` if that
-        RPC failed. Intended for support tickets.
+        `listpeerchannels`, `listfunds`); each value is the serialized
+        response, or `{ "error": "..." }` if that RPC failed. Payment and
+        invoice history are deliberately excluded to avoid leaking
+        preimages, payment hashes, bolt11 strings, and labels into support
+        dumps. Intended for support tickets.
         """
 
         raise NotImplementedError
@@ -5368,9 +5636,11 @@ class Node():
         Returns a pretty-printed JSON string with shape:
         `{ "timestamp": <unix-secs>, "node": { ... }, "sdk": { "version": ..., "node_state": ... } }`.
         The `node` object contains one entry per CLN RPC (`getinfo`,
-        `listpeerchannels`, `listfunds`, `listpays`, `listinvoices`); each
-        value is the serialized response, or `{ "error": "..." }` if that
-        RPC failed. Intended for support tickets.
+        `listpeerchannels`, `listfunds`); each value is the serialized
+        response, or `{ "error": "..." }` if that RPC failed. Payment and
+        invoice history are deliberately excluded to avoid leaking
+        preimages, payment hashes, bolt11 strings, and labels into support
+        dumps. Intended for support tickets.
         """
 
         return _UniffiConverterString.lift(
@@ -6117,6 +6387,37 @@ def register_or_recover(mnemonic: "str",invite_code: "typing.Optional[str]",conf
         _UniffiConverterTypeConfig.lower(config)))
 
 
+def set_log_level(level: "LogLevel") -> None:
+    """
+    Change the log filter at runtime without reinstalling the listener.
+    """
+
+    _UniffiConverterTypeLogLevel.check_lower(level)
+    
+    _uniffi_rust_call(_UniffiLib.uniffi_glsdk_fn_func_set_log_level,
+        _UniffiConverterTypeLogLevel.lower(level))
+
+
+def set_logger(level: "LogLevel",listener: "LogListener") -> None:
+    """
+    Set up SDK logging. Call once before any other SDK function.
+
+    The listener receives all log messages from the SDK and the
+    underlying Greenlight client library. Call once, as early as
+    possible, so early logs are captured. Returns an error if a logger
+    has already been installed in this process. To change the filter
+    after installation, use `set_log_level`.
+    """
+
+    _UniffiConverterTypeLogLevel.check_lower(level)
+    
+    _UniffiConverterTypeLogListener.check_lower(listener)
+    
+    _uniffi_rust_call_with_error(_UniffiConverterTypeError,_UniffiLib.uniffi_glsdk_fn_func_set_logger,
+        _UniffiConverterTypeLogLevel.lower(level),
+        _UniffiConverterTypeLogListener.lower(listener))
+
+
 __all__ = [
     "InternalError",
     "ChannelSide",
@@ -6125,6 +6426,7 @@ __all__ = [
     "InputType",
     "InvoiceStatus",
     "ListIndex",
+    "LogLevel",
     "Network",
     "NodeEvent",
     "OutputStatus",
@@ -6143,6 +6445,7 @@ __all__ = [
     "ListPaysResponse",
     "ListPeerChannelsResponse",
     "ListPeersResponse",
+    "LogEntry",
     "NodeState",
     "OnchainReceiveResponse",
     "OnchainSendResponse",
@@ -6158,6 +6461,8 @@ __all__ = [
     "recover",
     "register",
     "register_or_recover",
+    "set_log_level",
+    "set_logger",
     "Config",
     "Credentials",
     "DeveloperCert",
@@ -6166,5 +6471,6 @@ __all__ = [
     "NodeEventStream",
     "Scheduler",
     "Signer",
+    "LogListener",
 ]
 

--- a/libs/gl-sdk/src/lib.rs
+++ b/libs/gl-sdk/src/lib.rs
@@ -27,6 +27,7 @@ pub enum Error {
 mod config;
 mod credentials;
 mod input;
+mod logging;
 mod node;
 mod scheduler;
 mod signer;
@@ -44,6 +45,7 @@ pub use crate::{
         Peer, PeerChannel, ReceiveResponse, SendResponse,
     },
     input::{InputType, ParsedInvoice},
+    logging::{LogEntry, LogLevel, LogListener},
     scheduler::Scheduler,
     signer::{Handle, Signer},
 };
@@ -217,6 +219,27 @@ pub fn register_or_recover(
 #[uniffi::export]
 pub fn parse_input(input: String) -> Result<input::InputType, Error> {
     input::parse_input(input)
+}
+
+/// Set up SDK logging. Call once before any other SDK function.
+///
+/// The listener receives all log messages from the SDK and the
+/// underlying Greenlight client library. Call once, as early as
+/// possible, so early logs are captured. Returns an error if a logger
+/// has already been installed in this process. To change the filter
+/// after installation, use `set_log_level`.
+#[uniffi::export]
+pub fn set_logger(
+    level: logging::LogLevel,
+    listener: Box<dyn logging::LogListener>,
+) -> Result<(), Error> {
+    logging::set_logger(level, listener)
+}
+
+/// Change the log filter at runtime without reinstalling the listener.
+#[uniffi::export]
+pub fn set_log_level(level: logging::LogLevel) {
+    logging::set_log_level(level)
 }
 
 #[derive(uniffi::Enum, Debug)]

--- a/libs/gl-sdk/src/logging.rs
+++ b/libs/gl-sdk/src/logging.rs
@@ -1,0 +1,120 @@
+// SDK logging — apps install a LogListener to receive log output
+// emitted by this SDK and by the underlying gl-client library.
+//
+// The bridge sits on top of the `log` crate facade: gl-sdk's own
+// `tracing` calls are routed via `tracing`'s `log` feature, and
+// gl-client's direct `log::*!` calls flow through the same channel.
+
+use crate::Error;
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+/// Log level for filtering messages.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<Level> for LogLevel {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Error => LogLevel::Error,
+            Level::Warn => LogLevel::Warn,
+            Level::Info => LogLevel::Info,
+            Level::Debug => LogLevel::Debug,
+            Level::Trace => LogLevel::Trace,
+        }
+    }
+}
+
+impl From<LogLevel> for LevelFilter {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Error => LevelFilter::Error,
+            LogLevel::Warn => LevelFilter::Warn,
+            LogLevel::Info => LevelFilter::Info,
+            LogLevel::Debug => LevelFilter::Debug,
+            LogLevel::Trace => LevelFilter::Trace,
+        }
+    }
+}
+
+/// A single log message from the SDK.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct LogEntry {
+    pub level: LogLevel,
+    pub message: String,
+    /// The module that produced this log (e.g. "gl_client::scheduler").
+    pub target: String,
+    /// Source file path, if the log macro recorded one.
+    pub file: Option<String>,
+    /// Source line number, if the log macro recorded one.
+    pub line: Option<u32>,
+}
+
+/// Callback interface for receiving log messages.
+///
+/// `on_log` is invoked on the thread that emitted the log — which can
+/// be any tokio worker or background thread inside the SDK. Keep the
+/// implementation cheap and non-blocking; if you need UI updates,
+/// hand the entry off to your app's main thread.
+#[uniffi::export(callback_interface)]
+pub trait LogListener: Send + Sync {
+    fn on_log(&self, entry: LogEntry);
+}
+
+struct SdkLogger {
+    listener: Box<dyn LogListener>,
+}
+
+impl Log for SdkLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        // Use the `log` crate's global max level so `set_log_level`
+        // can change the filter at runtime. `log::max_level()` is an
+        // atomic read that every log macro also consults.
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            self.listener.on_log(LogEntry {
+                level: record.level().into(),
+                message: record.args().to_string(),
+                target: record.target().to_string(),
+                file: record.file().map(|s| s.to_string()),
+                line: record.line(),
+            });
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Install a log listener. Call this once, as early as possible, so
+/// logs emitted during node bring-up are captured.
+///
+/// Returns `Err` if a logger is already installed in the process
+/// (either from an earlier successful call to `set_logger` or from a
+/// different crate). To change the filter after installation use
+/// `set_log_level`.
+pub fn set_logger(level: LogLevel, listener: Box<dyn LogListener>) -> Result<(), Error> {
+    let filter: LevelFilter = level.into();
+    log::set_boxed_logger(Box::new(SdkLogger { listener })).map_err(|e| {
+        Error::Other(format!("a `log` logger is already installed: {e}"))
+    })?;
+    log::set_max_level(filter);
+    Ok(())
+}
+
+/// Change the log filter at runtime without reinstalling the listener.
+///
+/// Useful for features like a "verbose logs" toggle in app settings.
+/// Safe to call before `set_logger` — it adjusts the `log` crate's
+/// global max level immediately; the listener (if any) picks it up
+/// on the next emitted message.
+pub fn set_log_level(level: LogLevel) {
+    log::set_max_level(level.into());
+}

--- a/libs/gl-sdk/src/node.rs
+++ b/libs/gl-sdk/src/node.rs
@@ -584,6 +584,70 @@ impl Node {
             inner: Mutex::new(stream),
         }))
     }
+
+    /// Collect a diagnostic snapshot of the node and SDK state.
+    ///
+    /// Returns a pretty-printed JSON string with shape:
+    /// `{ "timestamp": <unix-secs>, "node": { ... }, "sdk": { "version": ..., "node_state": ... } }`.
+    /// The `node` object contains one entry per CLN RPC (`getinfo`,
+    /// `listpeerchannels`, `listfunds`); each value is the serialized
+    /// response, or `{ "error": "..." }` if that RPC failed. Payment and
+    /// invoice history are deliberately excluded to avoid leaking
+    /// preimages, payment hashes, bolt11 strings, and labels into support
+    /// dumps. Intended for support tickets.
+    pub fn generate_diagnostic_data(&self) -> Result<String, Error> {
+        self.check_connected()?;
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let getinfo = render_section(self.get_info());
+        let listpeerchannels = render_section(self.list_peer_channels());
+        let listfunds = render_section(self.list_funds());
+        let node_state = render_section(self.node_state());
+
+        build_diagnostic_json(
+            timestamp,
+            env!("CARGO_PKG_VERSION"),
+            getinfo,
+            listpeerchannels,
+            listfunds,
+            node_state,
+        )
+    }
+}
+
+fn render_section<T: serde::Serialize>(result: Result<T, Error>) -> serde_json::Value {
+    match result {
+        Ok(v) => serde_json::to_value(&v)
+            .unwrap_or_else(|e| serde_json::json!({ "error": e.to_string() })),
+        Err(e) => serde_json::json!({ "error": e.to_string() }),
+    }
+}
+
+fn build_diagnostic_json(
+    timestamp: u64,
+    sdk_version: &str,
+    getinfo: serde_json::Value,
+    listpeerchannels: serde_json::Value,
+    listfunds: serde_json::Value,
+    node_state: serde_json::Value,
+) -> Result<String, Error> {
+    let envelope = serde_json::json!({
+        "timestamp": timestamp,
+        "node": {
+            "getinfo": getinfo,
+            "listpeerchannels": listpeerchannels,
+            "listfunds": listfunds,
+        },
+        "sdk": {
+            "version": sdk_version,
+            "node_state": node_state,
+        }
+    });
+    serde_json::to_string_pretty(&envelope).map_err(|e| Error::Other(e.to_string()))
 }
 
 // Not exported through uniffi
@@ -713,7 +777,7 @@ pub struct ReceiveResponse {
     pub opening_fee_msat: u64,
 }
 
-#[derive(uniffi::Enum, Clone)]
+#[derive(uniffi::Enum, Clone, serde::Serialize)]
 pub enum PayStatus {
     COMPLETE = 0,
     PENDING = 1,
@@ -746,7 +810,7 @@ impl From<i32> for PayStatus {
 // ============================================================
 
 #[allow(unused)]
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct GetInfoResponse {
     /// Node public key as lowercase hex (66 chars).
     pub id: String,
@@ -831,13 +895,13 @@ impl From<clnpb::ListpeersPeers> for Peer {
 // ============================================================
 
 #[allow(unused)]
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct ListPeerChannelsResponse {
     pub channels: Vec<PeerChannel>,
 }
 
 #[allow(unused)]
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct PeerChannel {
     /// Peer node public key as lowercase hex (66 chars).
     pub peer_id: String,
@@ -863,7 +927,7 @@ pub struct PeerChannel {
 }
 
 /// Which side of a channel performed a given action (e.g. initiated close).
-#[derive(Clone, uniffi::Enum)]
+#[derive(Clone, serde::Serialize, uniffi::Enum)]
 pub enum ChannelSide {
     Local,
     Remote,
@@ -879,7 +943,7 @@ impl ChannelSide {
     }
 }
 
-#[derive(Clone, uniffi::Enum)]
+#[derive(Clone, serde::Serialize, uniffi::Enum)]
 pub enum ChannelState {
     Openingd,
     ChanneldAwaitingLockin,
@@ -992,14 +1056,14 @@ impl From<clnpb::ListpeerchannelsChannels> for PeerChannel {
 // ============================================================
 
 #[allow(unused)]
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct ListFundsResponse {
     pub outputs: Vec<FundOutput>,
     pub channels: Vec<FundChannel>,
 }
 
 #[allow(unused)]
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct FundOutput {
     /// Transaction id as lowercase hex (64 chars).
     pub txid: String,
@@ -1015,7 +1079,7 @@ pub struct FundOutput {
     pub reserved: bool,
 }
 
-#[derive(Clone, uniffi::Enum)]
+#[derive(Clone, serde::Serialize, uniffi::Enum)]
 pub enum OutputStatus {
     Unconfirmed,
     Confirmed,
@@ -1036,7 +1100,7 @@ impl OutputStatus {
 }
 
 #[allow(unused)]
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct FundChannel {
     /// Peer node public key as lowercase hex (66 chars).
     pub peer_id: String,
@@ -1117,7 +1181,7 @@ impl ListIndex {
 // ListInvoices response types
 // ============================================================
 
-#[derive(Clone, uniffi::Enum)]
+#[derive(Clone, serde::Serialize, uniffi::Enum)]
 pub enum InvoiceStatus {
     UNPAID,
     PAID,
@@ -1135,7 +1199,7 @@ impl From<i32> for InvoiceStatus {
     }
 }
 
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct Invoice {
     pub label: String,
     pub description: String,
@@ -1180,7 +1244,7 @@ impl From<clnpb::ListinvoicesInvoices> for Invoice {
     }
 }
 
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct ListInvoicesResponse {
     pub invoices: Vec<Invoice>,
 }
@@ -1197,7 +1261,7 @@ impl From<clnpb::ListinvoicesResponse> for ListInvoicesResponse {
 // ListPays response types
 // ============================================================
 
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct Pay {
     /// Payment hash as lowercase hex (64 chars).
     pub payment_hash: String,
@@ -1243,7 +1307,7 @@ impl From<clnpb::ListpaysPays> for Pay {
     }
 }
 
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct ListPaysResponse {
     pub pays: Vec<Pay>,
 }
@@ -1394,7 +1458,7 @@ impl From<clnpb::ListpaysPays> for Payment {
 /// connectivity. Returned by `node_state()`.
 ///
 /// All amounts are in millisatoshis (1 sat = 1000 msat).
-#[derive(Clone, uniffi::Record)]
+#[derive(Clone, serde::Serialize, uniffi::Record)]
 pub struct NodeState {
     /// The node's public key as a lowercase hex string (66 chars).
     pub id: String,
@@ -1574,3 +1638,4 @@ impl From<glpb::NodeEvent> for NodeEvent {
         }
     }
 }
+

--- a/libs/gl-sdk/tests/test_logging.py
+++ b/libs/gl-sdk/tests/test_logging.py
@@ -1,0 +1,67 @@
+"""Tests for the SDK logging framework.
+
+`set_logger` installs a process-wide logger on the `log` crate — only
+one install succeeds per process. Tests that exercise the install path
+are ordered / deduped so we don't cascade failures.
+"""
+
+import glsdk
+
+
+class TestLoggingTypes:
+    """Type surface exists in the bindings."""
+
+    def test_log_level_enum(self):
+        assert hasattr(glsdk, "LogLevel")
+        for variant in ("ERROR", "WARN", "INFO", "DEBUG", "TRACE"):
+            assert hasattr(glsdk.LogLevel, variant)
+
+    def test_log_entry_type(self):
+        assert hasattr(glsdk, "LogEntry")
+
+    def test_log_listener_type(self):
+        assert hasattr(glsdk, "LogListener")
+
+    def test_set_logger_function(self):
+        assert hasattr(glsdk, "set_logger")
+
+    def test_set_log_level_function(self):
+        assert hasattr(glsdk, "set_log_level")
+
+
+class TestLogEntryShape:
+    """LogEntry carries level / message / target / file / line."""
+
+    def test_log_entry_fields(self):
+        entry = glsdk.LogEntry(
+            level=glsdk.LogLevel.INFO,
+            message="hello",
+            target="gl_sdk::test",
+            file="src/test.rs",
+            line=42,
+        )
+        assert entry.level == glsdk.LogLevel.INFO
+        assert entry.message == "hello"
+        assert entry.target == "gl_sdk::test"
+        assert entry.file == "src/test.rs"
+        assert entry.line == 42
+
+    def test_log_entry_file_line_optional(self):
+        entry = glsdk.LogEntry(
+            level=glsdk.LogLevel.ERROR,
+            message="oops",
+            target="gl_sdk",
+            file=None,
+            line=None,
+        )
+        assert entry.file is None
+        assert entry.line is None
+
+
+class TestSetLogLevel:
+    """`set_log_level` is callable without a listener installed."""
+
+    def test_set_log_level_no_raise(self):
+        # Safe to call before/after / without set_logger
+        glsdk.set_log_level(glsdk.LogLevel.WARN)
+        glsdk.set_log_level(glsdk.LogLevel.TRACE)

--- a/libs/gl-sdk/tests/test_node_methods.py
+++ b/libs/gl-sdk/tests/test_node_methods.py
@@ -4,6 +4,8 @@ These tests verify that the UniFFI bindings correctly expose the new Node method
 and their response types.
 """
 
+import json
+
 import pytest
 import glsdk
 from gltesting.fixtures import *
@@ -318,4 +320,49 @@ class TestNodeStateMethod:
         assert state.total_channel_capacity_msat == 0
         assert state.onchain_balance_msat == 0
         assert state.total_inbound_liquidity_msat == 0
+        node.disconnect()
+
+
+class TestGenerateDiagnosticData:
+    """Test generate_diagnostic_data() on a freshly registered node."""
+
+    def test_node_has_generate_diagnostic_data_method(self):
+        assert hasattr(glsdk.Node, "generate_diagnostic_data")
+
+    def test_generate_diagnostic_data_returns_well_formed_envelope(
+        self, scheduler, nobody_id
+    ):
+        dev_cert = glsdk.DeveloperCert(nobody_id.cert_chain, nobody_id.private_key)
+        config = glsdk.Config().with_developer_cert(dev_cert)
+        node = glsdk.register_or_recover(MNEMONIC, None, config)
+
+        blob = node.generate_diagnostic_data()
+        assert isinstance(blob, str)
+
+        parsed = json.loads(blob)
+        assert isinstance(parsed["timestamp"], int)
+        assert parsed["timestamp"] > 0
+
+        assert "sdk" in parsed
+        assert isinstance(parsed["sdk"]["version"], str)
+        assert parsed["sdk"]["version"] != ""
+        # node_state should serialize as a JSON object on a healthy node.
+        assert isinstance(parsed["sdk"]["node_state"], dict)
+        assert parsed["sdk"]["node_state"]["network"] == "regtest"
+
+        assert "node" in parsed
+        for key in ("getinfo", "listpeerchannels", "listfunds"):
+            assert key in parsed["node"], f"missing node section: {key}"
+        # Payment/invoice history is intentionally excluded from the dump.
+        assert "listpays" not in parsed["node"]
+        assert "listinvoices" not in parsed["node"]
+
+        # Healthy node: getinfo should serialize as an object, not as
+        # {"error": "..."}.
+        getinfo = parsed["node"]["getinfo"]
+        assert isinstance(getinfo, dict)
+        assert "error" not in getinfo
+        assert isinstance(getinfo["id"], str)
+        assert len(getinfo["id"]) == 66
+
         node.disconnect()


### PR DESCRIPTION
[Two callback-based listener APIs for mobile integrators, both
following the Breez SDK shape.

Logging
- LogListener: apps implement on_log(LogEntry) to receive log messages
  from both gl-sdk (via tracing's log bridge) and gl-client (111
  log::*! callsites flow through automatically).
- LogEntry carries level, message, target module, and source file + line
  for easier triage of production issues.
- LogLevel variants use Rust PascalCase (Error/Warn/Info/Debug/Trace)
  matching the ChannelState/OutputStatus/PaymentStatus convention;
  bindings still render as UPPER_SNAKE per uniffi convention.
- set_logger(level, listener) returns Result<(), Error>. First call
  installs; subsequent calls are silent no-ops. Returns an error only
  when another crate has already installed a log logger, replacing the
  previous .expect("logger already set") panic.
- Exposed to JS via a NAPI wrapper that bridges a ThreadsafeFunction to
  LogListener (napi4 feature enabled).

Node events
- NodeEventListener: apps implement on_event(NodeEvent) to receive live
  events (InvoicePaid today; room for more).
- Replaces the pull-based NodeEventStream + next() surface entirely.
  NodeEventStream is gone.
- Listener is strictly a connect-time concern:
  register / recover / connect / register_or_recover each gain an
  event_listener: Option<Box<dyn NodeEventListener>> parameter. The
  SDK installs it atomically during node bring-up, so events that fire
  during the first round of RPCs are not missed.
- set_event_listener is pub(crate) — not exposed via uniffi or NAPI.
  Callers who need post-construction flexibility wire a mutable delegate
  inside their listener implementation (Flow/LiveData/ObservableObject
  pattern). Matches Breez's EventListener shape.
- Single listener per Node. Drop for Node aborts the dispatch task so
  teardown is automatic.

Tests
- Python test_logging.py asserts the logging types exist and set_logger
  accepts a listener.
- Kotlin LoggingTest.kt installs a listener and drives register_or_recover
  as a smoke test for cross-language log capture.](https://github.com/Blockstream/greenlight/pull/705#issue-4323195598)
  
  +
  
  feat(gl-sdk): add generate_diagnostic_data for support dumps

Returns a pretty-printed JSON envelope { timestamp, node, sdk } where
the node section serializes getinfo/listpeerchannels/listfunds and the
sdk section carries version + node_state. Failed sub-calls are embedded
as { "error": "..." } instead of failing the dump. Adds serde derive on
the response types so each section is real nested JSON, queryable with
jq. Payment and invoice history are intentionally excluded to avoid
leaking preimages, payment hashes, bolt11 strings, and labels into
support dumps.