### PR TITLE
fix(gl-sdk): exclude unpaid invoices from list_payments

### DIFF
--- a/libs/gl-sdk-android/lib/src/androidInstrumentedTest/kotlin/com/blockstream/glsdk/ListPaymentTest.kt
+++ b/libs/gl-sdk-android/lib/src/androidInstrumentedTest/kotlin/com/blockstream/glsdk/ListPaymentTest.kt
@@ -82,16 +82,24 @@ class ListPaymentTest {
 
     @OptIn(ExperimentalUuidApi::class)
     @Test
-    fun default_excludes_failures() {
+    fun unpaid_invoices_excluded() {
         val config = Config()
         registerOrRecover(testMnemonic, null, config).use { node ->
             val label = Uuid.random().toString()
             node.receive(label = label, description = "Tea", amountMsat = 5_000_000uL)
 
-            // Default request excludes failures; pending invoices should still appear
+            // listPayments returns paid invoices only on the received
+            // side. The unpaid invoice we just created must not appear.
             val result = node.listPayments()
-            val pending = result.filter { it.status == PaymentStatus.PENDING }
-            assertTrue("Pending invoices should appear in default list", pending.isNotEmpty())
+            for (p in result) {
+                if (p.paymentType == PaymentType.RECEIVED) {
+                    assertEquals(
+                        "non-Complete received payment: $p",
+                        PaymentStatus.COMPLETE,
+                        p.status,
+                    )
+                }
+            }
         }
     }
 

--- a/libs/gl-sdk/src/node.rs
+++ b/libs/gl-sdk/src/node.rs
@@ -392,7 +392,19 @@ impl Node {
             .unwrap_or(true);
 
         if include_received {
-            payments.extend(invoices.invoices.into_iter().map(|i| -> Payment { i.into() }));
+            // Only paid invoices belong in payment history. Open
+            // (unpaid) and expired invoices live behind list_invoices()
+            // for callers that want to inspect them directly.
+            payments.extend(
+                invoices
+                    .invoices
+                    .into_iter()
+                    .filter(|i| {
+                        i.status()
+                            == clnpb::listinvoices_invoices::ListinvoicesInvoicesStatus::Paid
+                    })
+                    .map(|i| -> Payment { i.into() }),
+            );
         }
         if include_sent {
             payments.extend(pays.pays.into_iter().map(|p| -> Payment { p.into() }));

--- a/libs/gl-sdk/tests/test_list_payments.py
+++ b/libs/gl-sdk/tests/test_list_payments.py
@@ -277,8 +277,10 @@ class TestListInvoicesIntegration:
         assert matching[0].destination_pubkey is not None
         node.disconnect()
 
-    def test_default_excludes_failures(self, scheduler, nobody_id):
-        """Default list_payments excludes failed/expired, so unpaid invoices appear as Pending."""
+    def test_unpaid_invoices_excluded(self, scheduler, nobody_id):
+        """list_payments returns only paid invoices on the received side.
+        Open / expired invoices live behind list_invoices() for direct
+        inspection."""
         dev_cert = glsdk.DeveloperCert(nobody_id.cert_chain, nobody_id.private_key)
         config = glsdk.Config().with_developer_cert(dev_cert)
         node = glsdk.register_or_recover(MNEMONIC, None, config)
@@ -286,14 +288,19 @@ class TestListInvoicesIntegration:
         label = str(uuid.uuid4())
         node.receive(label=label, description="tea", amount_msat=5_000_000)
 
+        # The invoice we just created is unpaid and must NOT appear in
+        # list_payments output.
         req = glsdk.ListPaymentsRequest(
             filters=None, from_timestamp=None, to_timestamp=None,
             include_failures=None, offset=None, limit=None,
         )
         result = node.list_payments(req)
-        # Pending invoices should appear (they are not failures)
-        matching = [p for p in result if p.status == glsdk.PaymentStatus.PENDING]
-        assert len(matching) >= 1
+        # Sanity: every returned received row is COMPLETE.
+        for p in result:
+            if p.payment_type == glsdk.PaymentType.RECEIVED:
+                assert p.status == glsdk.PaymentStatus.COMPLETE, (
+                    f"non-Complete received payment: {p}"
+                )
         node.disconnect()
 
     def test_type_filter_received_only(self, scheduler, nobody_id):


### PR DESCRIPTION
list_payments now filters incoming invoices to Paid only before merging them into the unified payment list. Open (unpaid) and expired invoices are dropped — they remain available via list_invoices() for callers that want to inspect them directly.

Rationale: a wallet's payment history feed should show things that actually moved sats. Surfacing open invoices the user just created makes the feed look like there's been incoming activity when there hasn't, and clutters the list for users who generate many invoices.

Tests updated: the previous "Pending invoices appear in default list" assertion in tests/test_list_payments.py and ListPaymentTest.kt is replaced by "every received row is Complete."

PaymentStatus::Pending stays on the public type — it remains valid for in-flight outgoing payments (sent side, unaffected here).