### PR TITLE
fix(ci): pin protoc to v3.19.4

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,9 +55,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        
+
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           version: "23.2" # Fixed since we mount the path below
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
         with:
           version: "latest"
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           version: "23.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/rust-unit.yml
+++ b/.github/workflows/rust-unit.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@v3
         with:
             version: "23.2"  # Fixed since we mount the path below
             repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The arduino/setup-protoc action is failing to resolve the latest version. Pinning to an older, stable version to unblock CI.