### PR TITLE
fix(gl-client): use webpki-roots for cross-platform LNURL TLS

### DIFF
--- a/libs/gl-client/Cargo.toml
+++ b/libs/gl-client/Cargo.toml
@@ -34,9 +34,22 @@ picky-asn1-der = "0.4"
 pin-project = "1.1.5"
 prost = "0.12"
 prost-derive = "0.12"
+# `rustls-tls-webpki-roots` compiles Mozilla's CA bundle into the
+# binary. Identical TLS behaviour on every platform — Android, iOS,
+# desktop — with no runtime OS root-store discovery. We previously
+# used `rustls-tls-native-roots`, which silently returned an empty
+# cert set on some Android variants and broke every HTTPS request
+# from `LnUrlHttpClearnetClient` with `UnknownIssuer`.
+#
+# When bumping reqwest to 0.12+, switch to `rustls-platform-verifier`
+# instead. It uses Android's `KeyStore` (via JNI), iOS's `SecTrust`,
+# and the Windows / macOS native verifiers — strictly better than
+# either webpki-roots (CA updates follow OS) or native-roots (no
+# discovery breakage). Requires reqwest >= 0.12, which we don't have
+# on this 0.11 line.
 reqwest = { version = "^0.11", features = [
     "json",
-    "rustls-tls-native-roots",
+    "rustls-tls-webpki-roots",
 ], default-features = false }
 ring = "~0.16.20"
 runeauth = "0.1"


### PR DESCRIPTION
## Summary

`rustls-tls-native-roots` loads root CAs from the OS at runtime via the `rustls-native-certs` crate. On Android this reads `/system/etc/security/cacerts/`, which silently returns no certs on some Android variants (newer API levels, custom ROMs, apps without read access). When that happens, every HTTPS request from `LnUrlHttpClearnetClient` (`gl-client/src/lnurl/models.rs:171`) fails with:

```
error trying to connect: invalid peer certificate: UnknownIssuer
```

This breaks Lightning Address resolution and every LNURL flow on the affected configurations.

This PR switches to `rustls-tls-webpki-roots`, which compiles Mozilla's CA bundle into the binary. Identical behaviour on every platform, no runtime root-store discovery, no platform-specific code paths.

## Trade-offs

- ✅ **Cross-platform.** Works on Android (any API level), iOS, desktop — no OS-specific cert-store quirks.
- ✅ **No JNI / platform code.** Standard reqwest config.
- ✅ **Standard for Rust mobile SDKs.** LDK, BDK, and most other Rust mobile libs ship this way.
- ⚠️ **~250 KB binary increase.** Mozilla CA list compiled in. Acceptable for a mobile SDK.
- ⚠️ **CA-bundle updates require an SDK release** rather than following the OS. In practice CA changes affecting real-world LNURL servers are rare enough that this is a non-issue, and the previous behaviour was outright broken on the affected Android configurations.

## Why not `rustls-platform-verifier`?

The modern best-practice for mobile is `rustls-platform-verifier`, which uses Android's `KeyStore` (via JNI), iOS's `SecTrust`, etc. But it requires `reqwest` 0.12+, and gl-client is pinned to `^0.11`. Bumping reqwest is a much larger change with cascading dep updates and belongs in a separate PR.

## Test plan

- [x] `cargo build -p gl-client` — clean
- [x] `cargo build -p gl-sdk` — clean (transitive consumer)
- [ ] Verify Lightning Address resolution succeeds on the previously-broken Android device (e.g. resolve `someuser@walletofsatoshi.com`)
- [ ] Smoke test on iOS and desktop to confirm no regression

## Reference

Failure observed in production:
```
W com.blockstream.glsdk.Exception$Other: v1=error sending request for url
  (https://walletofsatoshi.com/.well-known/lnurlp/<user>):
  error trying to connect: invalid peer certificate: UnknownIssuer
```