### PR TITLE
release: gl-client 0.4.1, gl-sdk 0.2.1, gl-sdk-cli 0.1.1, gl-sdk-napi 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "gl-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "gl-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bip39",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "gl-sdk-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bip39",
  "clap",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "gl-sdk-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "gl-sdk",
@@ -2785,12 +2785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,7 +3487,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -3507,6 +3500,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3661,18 +3655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3739,15 +3721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3843,29 +3816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5240,6 +5190,12 @@ dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "weedle2"

--- a/libs/gl-client/CHANGELOG.md
+++ b/libs/gl-client/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [0.4.1] - 2026-04-30
+
+### Added
+
+- New `lnurl` module with full LNURL protocol support (LUD-01/03/06/09/10/16)
+- `lnurl::pay::fetch_invoice()` free function for LNURL-pay invoice retrieval
+- `lnurl::withdraw::build_withdraw_callback_url()` free function for LNURL-withdraw
+- LNURL model types: `LnUrlPayRequestData`, `LnUrlWithdrawRequestData`, `LnUrlHttpClient` trait, `LnUrlHttpClearnetClient`
+- Lightning Address parsing via `lnurl::pay::parse_lightning_address()`
+- LNURL bech32 decoding via `lnurl::utils::parse_lnurl()`
+
+### Fixed
+
+- Use `webpki-roots` for LNURL TLS to support cross-platform builds (no dependency on system CA store)
+- Hardened LNURL-pay against real-world service quirks
+- Case-insensitive comparison for BOLT11 invoice strings in signer
+
 ## [0.4.0] - 2026-04-02
 
 ### Added
@@ -38,4 +55,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Addressed a deprecation warning in gl-testing regarding `PROTOCOL_TLS` being renamed to `PROTOCOL_TLS_SERVER`
 - Fixed initial VLS state not being persisted to the tower (nodelet)
 
+[0.4.1]: https://github.com/Blockstream/greenlight/compare/gl-client-v0.4.0...gl-client-v0.4.1
 [0.4.0]: https://github.com/Blockstream/greenlight/compare/gl-client-0.3.2...gl-client-v0.4.0

--- a/libs/gl-client/Cargo.toml
+++ b/libs/gl-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-client"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = [
   "The Greenlight Team"

--- a/libs/gl-sdk-android/gradle.properties
+++ b/libs/gl-sdk-android/gradle.properties
@@ -29,4 +29,4 @@ kotlin.mpp.enableCInteropCommonization=true
 android.builtInKotlin=false
 android.newDsl=false
 
-libraryVersion=0.2.0
+libraryVersion=0.2.1

--- a/libs/gl-sdk-cli/CHANGELOG.md
+++ b/libs/gl-sdk-cli/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.1.1] - 2026-04-30
+
+### Changed
+
+- Updated gl-sdk dependency to 0.2.1 (builder-style Node creation, LNURL support, diagnostic data)
+
+## [0.1.0] - 2026-04-02
+
+### Added
+
+- Initial release with CLI wrapper for gl-sdk
+- `glsdk` binary with subcommands for node management
+
+[0.1.1]: https://github.com/Blockstream/greenlight/compare/gl-sdk-cli-v0.1.0...gl-sdk-cli-v0.1.1
+[0.1.0]: https://github.com/Blockstream/greenlight/releases/tag/gl-sdk-cli-v0.1.0

--- a/libs/gl-sdk-cli/Cargo.toml
+++ b/libs/gl-sdk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-sdk-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "CLI wrapper for gl-sdk"
 

--- a/libs/gl-sdk-napi/Cargo.toml
+++ b/libs/gl-sdk-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-sdk-node"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 

--- a/libs/gl-sdk-napi/package.json
+++ b/libs/gl-sdk-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greenlightcln/glsdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node.js bindings for Blockstream Greenlight SDK",
   "author": "The Greenlight Team",
   "main": "index.js",

--- a/libs/gl-sdk/CHANGELOG.md
+++ b/libs/gl-sdk/CHANGELOG.md
@@ -6,16 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [0.2.1] - 2026-04-30
+
 ### Added
 
 - `parse_input()` — synchronous, offline classification of user input. Recognises BOLT11 invoices, node IDs, LNURL bech32 strings (decoded to their underlying URL), and Lightning Addresses (returned as the unparsed `user@host` form). LNURL inputs are classified but not fetched; the cost contract is "no HTTP, no I/O." Use this for clipboard validation, invoice sanity checks, and any other path that must not touch the network.
 - `resolve_input()` — asynchronous, network-touching classification. Internally calls `parse_input()`, then for the LNURL / Lightning Address branches performs the HTTP GET to the service endpoint and returns typed pay or withdraw request data. BOLT11 invoices and node IDs pass through without I/O. Use this for the QR-scan flow that should proceed straight to a pay/withdraw screen.
 - `ParsedInput` enum (offline result): `Bolt11`, `NodeId`, `LnUrl { url }`, `LnUrlAddress { address }`.
 - `ResolvedInput` enum (resolved result): `Bolt11`, `NodeId`, `LnUrlPay { data }`, `LnUrlWithdraw { data }`.
+- Builder-style `Node` creation with signerless mode as default
+- `NodeState` snapshot with hex identifiers
+- `LogListener` for foreign-binding log capture
+- `generate_diagnostic_data()` for support dumps
 
 ### Removed
 
 - `Node::resolve_lnurl()` and the `ResolvedLnUrl` enum. Use `parse_input()` (offline) or `resolve_input()` (HTTP) to obtain `LnUrlPayRequestData` / `LnUrlWithdrawRequestData`, then call `Node::lnurl_pay()` / `Node::lnurl_withdraw()`.
+
+### Fixed
+
+- Hardened LNURL-pay against real-world services
+- Excluded unpaid invoices from `list_payments`
+- `list_payments` fixes for edge cases
 
 ## [0.2.0] - 2026-04-02
 
@@ -50,5 +62,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Updated gl-client dependency to support CLN v25.12 signer.
 
+[0.2.1]: https://github.com/Blockstream/greenlight/compare/gl-sdk-v0.2.0...gl-sdk-v0.2.1
 [0.2.0]: https://github.com/Blockstream/greenlight/compare/gl-sdk-v0.1.1...gl-sdk-v0.2.0
 [0.1.1]: https://github.com/Blockstream/greenlight/releases/tag/gl-sdk-v0.1.1

--- a/libs/gl-sdk/Cargo.toml
+++ b/libs/gl-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-sdk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "High-level SDK for Greenlight with UniFFI language bindings"
 license = "MIT"
@@ -13,7 +13,7 @@ name = "glsdk"
 [dependencies]
 anyhow = "1"
 bip39 = "2.2.0"
-gl-client = { version = "0.4.0", path = "../gl-client" }
+gl-client = { version = "0.4.1", path = "../gl-client" }
 hex = "0.4"
 log = "0.4"
 lightning-invoice = "0.33"

--- a/libs/gl-sdk/pyproject.toml
+++ b/libs/gl-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gl-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python bindings for Greenlight SDK using UniFFI"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump **gl-client** 0.4.0 → 0.4.1 (new `lnurl` module, LNURL TLS fix, signer hardening)
- Bump **gl-sdk** 0.2.0 → 0.2.1 (parse_input/resolve_input, builder-style Node, LogListener, diagnostics)
- Bump **gl-sdk-cli** 0.1.0 → 0.1.1 (tracks gl-sdk 0.2.1)
- Bump **gl-sdk-napi** / **@greenlightcln/glsdk** 0.1.0 → 0.1.1
- Bump **gl-sdk-android** 0.2.0 → 0.2.1
- Update **gl-sdk-swift** binary target URL to `gl-sdk-v0.2.1` release (checksum TBD after build)
- Updated changelogs for gl-client, gl-sdk, gl-sdk-cli

## Release tags (after merge)

Tags must be pushed in dependency order:

1. `gl-client-v0.4.1` — crates.io (gl-sdk depends on the new lnurl module)
2. `gl-sdk-v0.2.1` — crates.io + Kotlin build
3. `gl-sdk-cli-v0.1.1` — crates.io

NPM publish for `@greenlightcln/glsdk` triggers automatically on main merge via version change detection.

## Test plan

- [ ] CI passes (Rust, Python, TypeScript, Kotlin workflows)
- [ ] Swift xcframework builds and checksum is filled in before final merge
- [ ] After merge: push tags in order, verify crates.io publishes succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)