### PR TITLE
Command hex format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
  "futures",
  "gl-client",
  "hex",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "vls-core",

--- a/libs/gl-cli/Cargo.toml
+++ b/libs/gl-cli/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.4"
 thiserror = "2.0.11"
 tokio = "1.43.0"
 vls-core.workspace = true
+serde_json = "^1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/libs/gl-cli/src/bin/glcli.rs
+++ b/libs/gl-cli/src/bin/glcli.rs
@@ -1,14 +1,21 @@
 use clap::Parser;
 use gl_cli::{run, Cli};
+use serde_json::json;
 
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let json_print = cli.json;
 
     match run(cli).await {
         Ok(()) => (),
         Err(e) => {
-            println!("{}", e);
+            if json_print {
+                let j = json!({"error": e.to_string()});
+                println!("{}", serde_json::to_string_pretty(&j).unwrap());
+            } else {
+                println!("{}", e);
+            }
         }
     }
 }

--- a/libs/gl-cli/src/error.rs
+++ b/libs/gl-cli/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
 
     #[error(transparent)]
     UtilError(#[from] util::UtilsError),
+
+    #[error("Failed to serialize response: {0}")]
+    JsonResponseError(String),
 }
 
 impl Error {
@@ -30,6 +33,10 @@ impl Error {
 
     pub fn credentials_not_found(e: impl std::fmt::Display) -> Error {
         Error::CredentialsNotFoundError(e.to_string())
+    }
+
+    pub fn failed_response_serialization(e: impl std::fmt::Display) -> Error {
+        Error::JsonResponseError(e.to_string())
     }
 }
 

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -183,3 +183,19 @@ impl ToJsonHex for cln::StopResponse {
         json!({})
     }
 }
+
+impl ToJsonHex for cln::CloseResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "item_type": self.item_type,
+        });
+        if let Some(x) = &self.tx {
+            j["tx"] = json!(hex::encode(x));
+        }
+        if let Some(x) = &self.txid {
+            j["txid"] = json!(hex::encode(x));
+        }
+
+        j
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -93,3 +93,55 @@ impl ToJsonHex for cln::PayResponse {
         j
     }
 }
+
+impl ToJsonHex for cln::ListpaysPays {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "payment_hash": hex::encode(&self.payment_hash),
+            "status": self.status,
+            "created_at": self.created_at,
+        });
+        if let Some(x) = &self.destination {
+            j["destination"] = json!(hex::encode(x));
+        }
+        if let Some(x) = self.completed_at {
+            j["completed_at"] = json!(x);
+        }
+        if let Some(x) = &self.label {
+            j["label"] = json!(x);
+        }
+        if let Some(x) = &self.bolt11 {
+            j["bolt11"] = json!(x);
+        }
+        if let Some(x) = &self.description {
+            j["description"] = json!(x);
+        }
+        if let Some(x) = &self.bolt12 {
+            j["bolt12"] = json!(x);
+        }
+        if let Some(x) = &self.amount_msat {
+            j["amount_msat"] = x.msat.into();
+        }
+        if let Some(x) = &self.amount_sent_msat {
+            j["amount_sent_msat"] = x.msat.into();
+        }
+        if let Some(x) = &self.preimage {
+            j["preimage"] = json!(hex::encode(x));
+        }
+        if let Some(x) = self.number_of_parts {
+            j["number_of_parts"] = json!(x);
+        }
+        if let Some(x) = &self.erroronion {
+            j["erroronion"] = json!(hex::encode(x));
+        }
+        j
+    }
+}
+
+impl ToJsonHex for cln::ListpaysResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        json!({
+            "pays": json!(self.pays.iter().map(|x| x.to_json_hex()).collect::<Vec<_>>())
+        })
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -1,0 +1,46 @@
+use gl_client::pb::cln;
+use serde_json::json;
+
+pub trait ToJsonHex {
+    fn to_json_hex(&self) -> serde_json::Value;
+}
+
+impl ToJsonHex for cln::GetinfoResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "id": hex::encode(&self.id),
+            "color": hex::encode(&self.color),
+            "num_peers": self.num_peers,
+            "num_pending_channels": self.num_pending_channels,
+            "num_active_channels": self.num_active_channels,
+            "num_inactive_channels": self.num_inactive_channels,
+            "address": self.address.clone(),
+            "binding": self.binding.clone(),
+            "version": self.version.clone(),
+            "blockheight": self.blockheight,
+            "network": self.network,
+            "lightning_dir": self.lightning_dir.clone(),
+        });
+        if let Some(alias) = &self.alias {
+            j["alias"] = json!(alias);
+        }
+        if let Some(amt) = &self.fees_collected_msat {
+            j["fees_collected_msat"] = amt.msat.into();
+        }
+        if let Some(feat) = &self.our_features {
+            j["our_features"] = json!({
+                "init": hex::encode(&feat.init),
+                "node": hex::encode(&feat.node),
+                "channel": hex::encode(&feat.channel),
+                "invoice": hex::encode(&feat.invoice),
+            });
+        }
+        if let Some(warn_bsync) = &self.warning_bitcoind_sync {
+            j["warning_bitcoind_sync"] = json!(warn_bsync);
+        }
+        if let Some(warn_lsync) = &self.warning_lightningd_sync {
+            j["warning_lightningd_sync"] = json!(warn_lsync);
+        }
+        j
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -20,12 +20,10 @@ impl ToJsonHex for cln::GetinfoResponse {
             "blockheight": self.blockheight,
             "network": self.network,
             "lightning_dir": self.lightning_dir.clone(),
+            "fees_collected_msat": self.fees_collected_msat.clone().map_or(0, |amt| amt.msat),
         });
         if let Some(alias) = &self.alias {
             j["alias"] = json!(alias);
-        }
-        if let Some(amt) = &self.fees_collected_msat {
-            j["fees_collected_msat"] = amt.msat.into();
         }
         if let Some(feat) = &self.our_features {
             j["our_features"] = json!({
@@ -40,6 +38,36 @@ impl ToJsonHex for cln::GetinfoResponse {
         }
         if let Some(warn_lsync) = &self.warning_lightningd_sync {
             j["warning_lightningd_sync"] = json!(warn_lsync);
+        }
+        j
+    }
+}
+
+impl ToJsonHex for cln::InvoiceResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "bolt11": self.bolt11.clone(),
+            "payment_hash": hex::encode(&self.payment_hash),
+            "payment_secret": hex::encode(&self.payment_secret),
+            "expires_at": self.expires_at,
+        });
+        if let Some(x) = self.created_index {
+            j["created_index"] = json!(x);
+        }
+        if let Some(x) = &self.warning_capacity {
+            j["warning_capacity"] = json!(x);
+        }
+        if let Some(x) = &self.warning_offline {
+            j["warning_offline"] = json!(x);
+        }
+        if let Some(x) = &self.warning_deadends {
+            j["warning_deadends"] = json!(x);
+        }
+        if let Some(x) = &self.warning_private_unused {
+            j["warning_private_unused"] = json!(x);
+        }
+        if let Some(x) = &self.warning_mpp {
+            j["warning_mpp"] = json!(x);
         }
         j
     }

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -72,3 +72,24 @@ impl ToJsonHex for cln::InvoiceResponse {
         j
     }
 }
+
+impl ToJsonHex for cln::PayResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "status": self.status,
+            "payment_preimage": hex::encode(&self.payment_preimage),
+            "payment_hash": hex::encode(&self.payment_hash),
+            "created_at": self.created_at,
+            "parts": self.parts,
+            "amount_msat": self.amount_msat.clone().map_or(0, |amt| amt.msat),
+            "amount_sent_msat": self.amount_sent_msat.clone().map_or(0, |amt| amt.msat),
+        });
+        if let Some(x) = &self.destination {
+            j["destination"] = json!(hex::encode(x));
+        }
+        if let Some(x) = &self.warning_partial_completion {
+            j["warning_partial_completion"] = json!(x);
+        }
+        j
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -281,3 +281,16 @@ impl ToJsonHex for cln::ListfundsResponse {
         })
     }
 }
+
+impl ToJsonHex for cln::NewaddrResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({});
+        if let Some(x) = &self.p2tr {
+            j["p2tr"] = json!(x);
+        }
+        if let Some(x) = &self.bech32 {
+            j["bech32"] = json!(x);
+        }
+        j
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -199,3 +199,22 @@ impl ToJsonHex for cln::CloseResponse {
         j
     }
 }
+
+impl ToJsonHex for cln::FundchannelResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "tx": hex::encode(&self.tx),
+            "txid": hex::encode(&self.txid),
+            "outnum": self.outnum,
+            "channel_id": hex::encode(&self.channel_id),
+        });
+        if let Some(x) = &self.close_to {
+            j["close_to"] = json!(hex::encode(x));
+        }
+        if let Some(x) = &self.mindepth {
+            j["mindepth"] = json!(x);
+        }
+
+        j
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -177,3 +177,9 @@ impl ToJsonHex for cln::ConnectResponse {
         j
     }
 }
+
+impl ToJsonHex for cln::StopResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        json!({})
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -228,3 +228,56 @@ impl ToJsonHex for cln::WithdrawResponse {
         })
     }
 }
+
+impl ToJsonHex for cln::ListfundsOutputs {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "txid": hex::encode(&self.txid),
+            "scriptpubkey": hex::encode(&self.scriptpubkey),
+            "output": self.output,
+            "amount_msat": self.amount_msat.clone().map_or(0, |amt| amt.msat),
+            "status": self.status,
+            "reserved": self.reserved
+        });
+        if let Some(x) = &self.address {
+            j["address"] = json!(x);
+        }
+        if let Some(x) = &self.redeemscript {
+            j["redeemscript"] = json!(hex::encode(x));
+        }
+        if let Some(x) = self.blockheight {
+            j["blockheight"] = json!(x);
+        }
+        j
+    }
+}
+
+impl ToJsonHex for cln::ListfundsChannels {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "peer_id": hex::encode(&self.peer_id),
+            "our_amount_msat": self.our_amount_msat.clone().map_or(0, |amt| amt.msat),
+            "amount_msat": self.amount_msat.clone().map_or(0, |amt| amt.msat),
+            "funding_txid": hex::encode(&self.funding_txid),
+            "funding_output": self.funding_output,
+            "connected": self.connected,
+            "state": self.state,
+        });
+        if let Some(x) = &self.channel_id {
+            j["channel_id"] = json!(hex::encode(x));
+        }
+        if let Some(x) = &self.short_channel_id {
+            j["short_channel_id"] = json!(x);
+        }
+        j
+    }
+}
+
+impl ToJsonHex for cln::ListfundsResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        json!({
+            "outputs": json!(self.outputs.iter().map(|x| x.to_json_hex()).collect::<Vec<_>>()),
+            "channels": json!(self.channels.iter().map(|x| x.to_json_hex()).collect::<Vec<_>>())
+        })
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -218,3 +218,13 @@ impl ToJsonHex for cln::FundchannelResponse {
         j
     }
 }
+
+impl ToJsonHex for cln::WithdrawResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        json!({
+            "tx": hex::encode(&self.tx),
+            "txid": hex::encode(&self.txid),
+            "psbt": self.psbt.clone(),
+        })
+    }
+}

--- a/libs/gl-cli/src/json_hex.rs
+++ b/libs/gl-cli/src/json_hex.rs
@@ -145,3 +145,35 @@ impl ToJsonHex for cln::ListpaysResponse {
         })
     }
 }
+
+impl ToJsonHex for cln::ConnectAddress {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "item_type": self.item_type,
+        });
+        if let Some(x) = &self.socket {
+            j["socket"] = json!(x);
+        }
+        if let Some(x) = &self.address {
+            j["address"] = json!(x);
+        }
+        if let Some(x) = &self.port {
+            j["port"] = json!(x);
+        }
+        j
+    }
+}
+
+impl ToJsonHex for cln::ConnectResponse {
+    fn to_json_hex(&self) -> serde_json::Value {
+        let mut j = json!({
+            "id": hex::encode(&self.id),
+            "features": hex::encode(&self.features),
+            "direction": self.direction,
+        });
+        if let Some(x) = &self.address {
+            j["address"] = x.to_json_hex();
+        }
+        j
+    }
+}

--- a/libs/gl-cli/src/lib.rs
+++ b/libs/gl-cli/src/lib.rs
@@ -20,6 +20,9 @@ pub struct Cli {
     network: Network,
     #[arg(long, short, global = true, help_heading = "Global options")]
     verbose: bool,
+    /// Produce json outputs.
+    #[arg(long, short, global = true, help_heading = "Global options")]
+    pub json: bool,
     #[command(subcommand)]
     cmd: Commands,
 }
@@ -57,6 +60,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 scheduler::Config {
                     data_dir,
                     network: cli.network,
+                    print_json: cli.json,
                 },
             )
             .await?
@@ -68,6 +72,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 signer::Config {
                     data_dir,
                     network: cli.network,
+                    print_json: cli.json,
                 },
             )
             .await?
@@ -78,6 +83,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 node::Config {
                     data_dir,
                     network: cli.network,
+                    print_json: cli.json,
                 },
             )
             .await?

--- a/libs/gl-cli/src/lib.rs
+++ b/libs/gl-cli/src/lib.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use gl_client::bitcoin::Network;
 use std::{path::PathBuf, str::FromStr};
 mod error;
+mod json_hex;
 pub mod model;
 mod node;
 mod scheduler;

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -441,7 +441,8 @@ async fn getinfo_handler<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
         let j = res.to_json_hex();
         println!(
             "{}",
-            serde_json::to_string_pretty(&j).map_err(|e| Error::custom(e.to_string()))?
+            serde_json::to_string_pretty(&j)
+                .map_err(|e| Error::failed_response_serialization(e))?
         );
     } else {
         println!("{:?}", res);

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -352,13 +352,14 @@ async fn newaddr_handler<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
 }
 
 async fn listfunds_handler<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .list_funds(cln::ListfundsRequest { spent: None })
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -434,13 +434,14 @@ async fn close_handler<P: AsRef<Path>>(config: Config<P>, id: String) -> Result<
 }
 
 async fn stop<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .stop(cln::StopRequest {})
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Result};
+use crate::json_hex::ToJsonHex;
 use crate::model;
 use crate::util::{self, CREDENTIALS_FILE_NAME, SEED_FILE_NAME};
 use clap::Subcommand;
@@ -429,13 +430,22 @@ async fn stop<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
 }
 
 async fn getinfo_handler<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .getinfo(cln::GetinfoRequest {})
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    if print_json {
+        let j = res.to_json_hex();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&j).map_err(|e| Error::custom(e.to_string()))?
+        );
+    } else {
+        println!("{:?}", res);
+    }
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 pub struct Config<P: AsRef<Path>> {
     pub data_dir: P,
     pub network: Network,
+    pub print_json: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -510,6 +510,7 @@ async fn listpays_handler<P: AsRef<Path>>(
     payment_hash: Option<Vec<u8>>,
     status: Option<i32>,
 ) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .list_pays(cln::ListpaysRequest {
@@ -523,7 +524,7 @@ async fn listpays_handler<P: AsRef<Path>>(
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -494,13 +494,14 @@ async fn connect_handler<P: AsRef<Path>>(
     host: Option<String>,
     port: Option<u32>,
 ) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .connect_peer(cln::ConnectRequest { id, host, port })
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -367,6 +367,7 @@ async fn withdraw_handler<P: AsRef<Path>>(
     destination: String,
     amount_sat: model::AmountSatOrAll,
 ) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .withdraw(cln::WithdrawRequest {
@@ -379,7 +380,7 @@ async fn withdraw_handler<P: AsRef<Path>>(
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -542,6 +542,7 @@ async fn pay_handler<P: AsRef<Path>>(
     maxfee: Option<u64>,
     description: Option<String>,
 ) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .pay(cln::PayRequest {
@@ -562,6 +563,6 @@ async fn pay_handler<P: AsRef<Path>>(
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -467,6 +467,7 @@ async fn invoice_handler<P: AsRef<Path>>(
     cltv: Option<u32>,
     deschashonly: Option<bool>,
 ) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .invoice(cln::InvoiceRequest {
@@ -483,7 +484,7 @@ async fn invoice_handler<P: AsRef<Path>>(
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -415,6 +415,7 @@ async fn fundchannel_handler<P: AsRef<Path>>(
 }
 
 async fn close_handler<P: AsRef<Path>>(config: Config<P>, id: String) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .close(cln::CloseRequest {
@@ -429,7 +430,7 @@ async fn close_handler<P: AsRef<Path>>(config: Config<P>, id: String) -> Result<
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -233,6 +233,21 @@ pub async fn command_handler<P: AsRef<Path>>(cmd: Command, config: Config<P>) ->
     }
 }
 
+macro_rules! print_json_or_pb {
+    ($print_json: expr, $obj: expr) => {
+        if $print_json {
+            let j = $obj.to_json_hex();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&j)
+                    .map_err(|e| Error::failed_response_serialization(e))?
+            );
+        } else {
+            println!("{:?}", $obj);
+        }
+    };
+}
+
 async fn init_handler<P: AsRef<Path>>(config: Config<P>, mnemonic: Option<String>) -> Result<()> {
     // Check if seed already exists in the configuration path
     let seed_path = config.data_dir.as_ref().join(SEED_FILE_NAME);
@@ -437,16 +452,7 @@ async fn getinfo_handler<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    if print_json {
-        let j = res.to_json_hex();
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&j)
-                .map_err(|e| Error::failed_response_serialization(e))?
-        );
-    } else {
-        println!("{:?}", res);
-    }
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -388,6 +388,7 @@ async fn fundchannel_handler<P: AsRef<Path>>(
     id: String,
     amount_sat: model::AmountSatOrAll,
 ) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let id_bytes = hex::FromHex::from_hex(&id)
         .map_err(|e| Error::custom(format!("Invalid hex string: {id}. {e}")))?;
@@ -410,7 +411,7 @@ async fn fundchannel_handler<P: AsRef<Path>>(
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/node.rs
+++ b/libs/gl-cli/src/node.rs
@@ -341,13 +341,14 @@ async fn log<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
 }
 
 async fn newaddr_handler<P: AsRef<Path>>(config: Config<P>) -> Result<()> {
+    let print_json = config.print_json;
     let mut node: gl_client::node::ClnClient = get_node(config).await?;
     let res = node
         .new_addr(cln::NewaddrRequest { addresstype: None })
         .await
         .map_err(|e| Error::custom(e.message()))?
         .into_inner();
-    println!("{:?}", res);
+    print_json_or_pb!(print_json, res);
     Ok(())
 }
 

--- a/libs/gl-cli/src/scheduler.rs
+++ b/libs/gl-cli/src/scheduler.rs
@@ -13,6 +13,7 @@ use util::{CREDENTIALS_FILE_NAME, SEED_FILE_NAME};
 pub struct Config<P: AsRef<Path>> {
     pub data_dir: P,
     pub network: Network,
+    pub print_json: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/libs/gl-cli/src/signer.rs
+++ b/libs/gl-cli/src/signer.rs
@@ -13,6 +13,7 @@ use util::{CREDENTIALS_FILE_NAME, SEED_FILE_NAME};
 pub struct Config<P: AsRef<Path>> {
     pub data_dir: P,
     pub network: Network,
+    pub print_json: bool,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]


### PR DESCRIPTION
Added json outputs to `gl-cli` commands.

For example:
```
$ glcli --json node getinfo
{
  "address": [],
  "alias": "...",
  "binding": [],
  "blockheight": 949533,
  "color": "...",
  "fees_collected_msat": 0,
  "id": "...",
  "lightning_dir": "/tmp/bitcoin",
  "network": "bitcoin",
  "num_active_channels": 0,
  "num_inactive_channels": 0,
  "num_peers": 1,
  "num_pending_channels": 0,
  "our_features": {
    "channel": "",
    "init": "0898880a8a59a1",
    "invoice": "02000002024100",
    "node": "8898880a8a59a1"
  },
  "version": "v25.12gl1"
}
```

I did this by hand, for every possible gRPC response that we use, which are not all of CLN's commands.
I know this is flawed, since we have no guarantee of correctedness by developer error or API changes and
as the number of gRPC commands grow this task becomes tedious.
But right now it is manageable and until we find a trick to make it automatic we can use this.