### PR TITLE
gl-sdk: Add C++ bindings

### DIFF
--- a/libs/gl-sdk/.tasks.yml
+++ b/libs/gl-sdk/.tasks.yml
@@ -94,6 +94,27 @@ tasks:
         npm install
         npm run build
 
+  bindings-cpp:
+    desc: "Generate C++ bindings (requires uniffi-bindgen-cpp)"
+    dir: "{{.TASKFILE_DIR}}/../.."
+    deps:
+      - task: build
+        vars: { CARGO_FLAGS: '{{if eq .PROFILE "release"}}--release{{else}}{{end}} --features cpp-bindings' }
+    cmds:
+      - |
+        cp ${CARGO_TARGET_DIR:-target}/{{.PROFILE_DIR}}/libglsdk.{{.LIB_EXT}} ./libs/gl-sdk/glsdk/libglsdk.{{.LIB_EXT}};
+        uniffi-bindgen-cpp \
+          --library ${CARGO_TARGET_DIR:-target}/{{.PROFILE_DIR}}/libglsdk.{{.LIB_EXT}} \
+          --out-dir ./libs/gl-sdk/bindings
+
+        # Patch generated C++ identifiers that conflict with reserved keyword `register`.
+        perl -pi -e \
+          's/std::shared_ptr<Node> register\(/std::shared_ptr<Node> register_node\(/g; s/std::shared_ptr<Credentials> register\(/std::shared_ptr<Credentials> register_node\(/g' \
+          "./libs/gl-sdk/bindings/glsdk.hpp"
+        perl -pi -e \
+          's/NodeBuilder::register\(/NodeBuilder::register_node\(/g; s/Scheduler::register\(/Scheduler::register_node\(/g' \
+          "./libs/gl-sdk/bindings/glsdk.cpp"
+
   bindings-all:
     desc: "Generate all language bindings"
     dir: "{{.TASKFILE_DIR}}/../.."
@@ -103,6 +124,7 @@ tasks:
       - bindings-swift
       - bindings-ruby
       - bindings-typescript
+      - bindings-cpp
 
   package-python:
     desc: "Build Python wheel package"

--- a/libs/gl-sdk/Cargo.toml
+++ b/libs/gl-sdk/Cargo.toml
@@ -29,3 +29,6 @@ url = "2"
 
 [build-dependencies]
 uniffi = { version = "0.29.4", features = [ "build" ] }
+
+[features]
+cpp-bindings = []

--- a/libs/gl-sdk/README.md
+++ b/libs/gl-sdk/README.md
@@ -36,6 +36,9 @@ task sdk:bindings-swift
 # Generate Ruby bindings
 task sdk:bindings-ruby
 
+# Generate C++ bindings (requires uniffi-bindgen-cpp)
+task sdk:bindings-cpp
+
 # Generate all language bindings
 task sdk:bindings-all
 ```
@@ -75,6 +78,32 @@ cargo run --bin uniffi-bindgen -- generate \
   --language kotlin \
   --out-dir ./libs/gl-sdk/bindings
 ```
+
+### Generate C++ Bindings
+
+C++ bindings use [uniffi-bindgen-cpp](https://github.com/NordSecurity/uniffi-bindgen-cpp) instead of the built-in `uniffi-bindgen`. Install it first:
+
+```bash
+cargo install uniffi-bindgen-cpp --git https://github.com/NordSecurity/uniffi-bindgen-cpp --tag v0.8.1+v0.29.4
+```
+
+Then build with the `cpp-bindings` feature and generate bindings:
+
+```bash
+cargo build --release -p gl-sdk --features cpp-bindings
+uniffi-bindgen-cpp --library target/release/libglsdk.dylib --out-dir libs/gl-sdk/bindings
+```
+
+> On Linux, replace `libglsdk.dylib` with `libglsdk.so`.
+
+The generated files require patching to avoid conflicts with the C++ reserved keyword `register`:
+
+```bash
+perl -pi -e 's/std::shared_ptr<Node> register\(/std::shared_ptr<Node> register_node\(/g; s/std::shared_ptr<Credentials> register\(/std::shared_ptr<Credentials> register_node\(/g' libs/gl-sdk/bindings/glsdk.hpp
+perl -pi -e 's/NodeBuilder::register\(/NodeBuilder::register_node\(/g; s/Scheduler::register\(/Scheduler::register_node\(/g' libs/gl-sdk/bindings/glsdk.cpp
+```
+
+The `task sdk:bindings-cpp` command handles all of the above automatically, including platform detection.
 
 ## Files
 

--- a/libs/gl-sdk/src/lib.rs
+++ b/libs/gl-sdk/src/lib.rs
@@ -259,9 +259,18 @@ pub fn parse_input(input: String) -> Result<input::ParsedInput, Error> {
 /// immediately without I/O.
 ///
 /// Strips `lightning:` / `LIGHTNING:` prefixes automatically.
+#[cfg(not(feature = "cpp-bindings"))]
 #[uniffi::export(async_runtime = "tokio")]
 pub async fn resolve_input(input: String) -> Result<input::ResolvedInput, Error> {
     input::resolve_input(input).await
+}
+
+/// Synchronously classify and resolve the input (C++ bindings).
+/// Note: This blocks the current thread. Use in a background thread if needed.
+#[cfg(feature = "cpp-bindings")]
+#[uniffi::export]
+pub fn resolve_input(input: String) -> Result<input::ResolvedInput, Error> {
+    util::exec(async { input::resolve_input(input).await })
 }
 
 /// Set up SDK logging. Call once before any other SDK function.


### PR DESCRIPTION
Adds C++ bindings support to `gl-sdk`:

- Introduce a `cpp-bindings` feature and C++ compatible `resolve_input` export.
- Add `task sdk:bindings-cpp` and include it in `task sdk:bindings-all`.
- Use `uniffi-bindgen-cpp` plus `perl` post-processing to rename generated `register` identifiers to `register_node`.
- Update the SDK README with C++ bindings setup and generation instructions.