### PR TITLE
release: gl-sdk 0.4.0, gl-client 0.6.0, gl-sdk-cli 0.3.0, gl-sdk-napi 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-21
+
 ### Fixed
 
  - Fixed signer rejecting valid `PreapproveInvoice` requests for uppercase bolt11 invoices by using case-insensitive comparison, matching the bech32 spec (BIP173). ([#698](https://github.com/Blockstream/greenlight/pull/698))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "gl-client"
-version = "0.4.1"
+version = "0.6.0"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "gl-sdk"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bip39",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "gl-sdk-cli"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "bip39",
  "clap",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "gl-sdk-node"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "gl-sdk",

--- a/libs/gl-cli/CHANGELOG.md
+++ b/libs/gl-cli/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- `--json` flag for machine-readable JSON output on all commands (invoice, pay, listpays, connect, stop, close, fundchannel, withdraw, listfunds, newaddr)
+
+### Changed
+
+- `fundchannel` now creates private channels by default
+
 ## [0.1.2] - 2026-01-16
 
 ### Added

--- a/libs/gl-cli/Cargo.toml
+++ b/libs/gl-cli/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4.5", features = ["derive"] }
 dirs = "6.0"
 env_logger = "0.11"
 futures = "0.3"
-gl-client = { version = "0.4", path = "../gl-client" }
+gl-client = { version = "0.6", path = "../gl-client" }
 hex = "0.4"
 thiserror = "2.0.11"
 tokio = "1.43.0"

--- a/libs/gl-client/CHANGELOG.md
+++ b/libs/gl-client/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-## [0.4.1] - 2026-04-30
+## [0.6.0] - 2026-05-21
 
 ### Added
 
@@ -16,17 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - LNURL model types: `LnUrlPayRequestData`, `LnUrlWithdrawRequestData`, `LnUrlHttpClient` trait, `LnUrlHttpClearnetClient`
 - Lightning Address parsing via `lnurl::pay::parse_lightning_address()`
 - LNURL bech32 decoding via `lnurl::utils::parse_lnurl()`
-
-### Fixed
-
-- Use `webpki-roots` for LNURL TLS to support cross-platform builds (no dependency on system CA store)
-- Hardened LNURL-pay against real-world service quirks
-- Case-insensitive comparison for BOLT11 invoice strings in signer
-
-## [0.4.0] - 2026-04-02
-
-### Added
-
 - New `metrics` module for signer state transfer instrumentation
 - New `Error::IllegalArgument` variant for improved error reporting
 - Signer now reports rejections to the server for debugging
@@ -50,10 +39,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Use `webpki-roots` for LNURL TLS to support cross-platform builds (no dependency on system CA store)
+- Hardened LNURL-pay against real-world service quirks
+- Case-insensitive comparison for BOLT11 invoice strings in signer
 - Addressed an issue with signers being unable to connect to the node, due to an SNI header override that is no longer required
 - Parsing an invalid certificate no longer panics, instead returning an error
 - Addressed a deprecation warning in gl-testing regarding `PROTOCOL_TLS` being renamed to `PROTOCOL_TLS_SERVER`
 - Fixed initial VLS state not being persisted to the tower (nodelet)
 
-[0.4.1]: https://github.com/Blockstream/greenlight/compare/gl-client-v0.4.0...gl-client-v0.4.1
-[0.4.0]: https://github.com/Blockstream/greenlight/compare/gl-client-0.3.2...gl-client-v0.4.0
+[0.6.0]: https://github.com/Blockstream/greenlight/compare/gl-client-0.3.2...gl-client-v0.6.0

--- a/libs/gl-client/Cargo.toml
+++ b/libs/gl-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-client"
-version = "0.4.1"
+version = "0.6.0"
 edition = "2021"
 authors = [
   "The Greenlight Team"

--- a/libs/gl-plugin/CHANGELOG.md
+++ b/libs/gl-plugin/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Removed
+
+- Legacy client-side LSPS2 `htlc_accepted` hook — JIT channel fee handling is now performed natively by CLN
+
 ## [0.3.1] - 2026-01-16
 
 ### Changed

--- a/libs/gl-plugin/Cargo.toml
+++ b/libs/gl-plugin/Cargo.toml
@@ -22,7 +22,7 @@ cln-plugin = "^0.1"
 cln-rpc = { workspace = true }
 env_logger = "^0.7.1"
 futures = "0.3"
-gl-client = { version = "^0.4.0", path = "../gl-client" }
+gl-client = { version = "^0.6.0", path = "../gl-client" }
 gl-util = { version = "0.1", path = "../gl-util" }
 governor = { version = "0.5", default-features = false, features = ["std"] }
 hex = "0.4"

--- a/libs/gl-sdk-android/gradle.properties
+++ b/libs/gl-sdk-android/gradle.properties
@@ -29,4 +29,4 @@ kotlin.mpp.enableCInteropCommonization=true
 android.builtInKotlin=false
 android.newDsl=false
 
-libraryVersion=0.2.1
+libraryVersion=0.4.0

--- a/libs/gl-sdk-cli/CHANGELOG.md
+++ b/libs/gl-sdk-cli/CHANGELOG.md
@@ -6,18 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-## [0.1.1] - 2026-04-30
-
-### Changed
-
-- Updated gl-sdk dependency to 0.2.1 (builder-style Node creation, LNURL support, diagnostic data)
-
-## [0.1.0] - 2026-04-02
+## [0.3.0] - 2026-05-21
 
 ### Added
 
 - Initial release with CLI wrapper for gl-sdk
 - `glsdk` binary with subcommands for node management
 
-[0.1.1]: https://github.com/Blockstream/greenlight/compare/gl-sdk-cli-v0.1.0...gl-sdk-cli-v0.1.1
-[0.1.0]: https://github.com/Blockstream/greenlight/releases/tag/gl-sdk-cli-v0.1.0
+### Changed
+
+- Updated gl-sdk dependency (builder-style Node creation, LNURL support, diagnostic data, on-chain preview, error codes)
+- Adapted `onchain_send` command for new optional `sat_per_vbyte` and `utxos` parameters
+
+[0.3.0]: https://github.com/Blockstream/greenlight/releases/tag/gl-sdk-cli-v0.3.0

--- a/libs/gl-sdk-cli/Cargo.toml
+++ b/libs/gl-sdk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-sdk-cli"
-version = "0.1.1"
+version = "0.3.0"
 edition = "2021"
 description = "CLI wrapper for gl-sdk"
 

--- a/libs/gl-sdk-napi/Cargo.toml
+++ b/libs/gl-sdk-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-sdk-node"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 

--- a/libs/gl-sdk-napi/package-lock.json
+++ b/libs/gl-sdk-napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@greenlightcln/glsdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@greenlightcln/glsdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.2.0",

--- a/libs/gl-sdk-napi/package.json
+++ b/libs/gl-sdk-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greenlightcln/glsdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Node.js bindings for Blockstream Greenlight SDK",
   "author": "The Greenlight Team",
   "main": "index.js",

--- a/libs/gl-sdk/CHANGELOG.md
+++ b/libs/gl-sdk/CHANGELOG.md
@@ -6,38 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-### Changed
-
-- `resolve_input()` is now **synchronous**, matching every other public SDK function. Async work (LNURL HTTP fetches) is executed internally on a shared Tokio runtime. Callers no longer need an async runtime or coroutine support; use native threading primitives to call off the main thread if needed.
-- Removed the `cpp-bindings` Cargo feature flag. A single build of the shared library now works for all language bindings (Python, Kotlin, Swift, Ruby, C++) without conditional compilation.
-
-## [0.2.1] - 2026-04-30
+## [0.4.0] - 2026-05-21
 
 ### Added
 
-- `parse_input()` — synchronous, offline classification of user input. Recognises BOLT11 invoices, node IDs, LNURL bech32 strings (decoded to their underlying URL), and Lightning Addresses (returned as the unparsed `user@host` form). LNURL inputs are classified but not fetched; the cost contract is "no HTTP, no I/O." Use this for clipboard validation, invoice sanity checks, and any other path that must not touch the network.
-- `resolve_input()` — asynchronous, network-touching classification. Internally calls `parse_input()`, then for the LNURL / Lightning Address branches performs the HTTP GET to the service endpoint and returns typed pay or withdraw request data. BOLT11 invoices and node IDs pass through without I/O. Use this for the QR-scan flow that should proceed straight to a pay/withdraw screen.
-- `ParsedInput` enum (offline result): `Bolt11`, `NodeId`, `LnUrl { url }`, `LnUrlAddress { address }`.
-- `ResolvedInput` enum (resolved result): `Bolt11`, `NodeId`, `LnUrlPay { data }`, `LnUrlWithdraw { data }`.
+- `prepare_onchain_send()` to preview on-chain send fee, recipient amount, and UTXO selection without broadcasting
+- `onchain_balance_state()` to classify wallet balance into UI-ready states (Available, ReserveOnly, PendingConfirmation, Immature, Unavailable)
+- `onchain_fee_rates()` to retrieve fee rate buckets (next-block through 1-day) from the node
+- New types: `PreparedOnchainSend`, `Outpoint`, `OnchainFeeRates`, `OnchainBalanceState`
+- C++ bindings support via UniFFI with build tasks for generating headers and shared library
+- `parse_input()` — synchronous, offline classification of user input. Recognises BOLT11 invoices, node IDs, LNURL bech32 strings (decoded to their underlying URL), and Lightning Addresses (returned as the unparsed `user@host` form). LNURL inputs are classified but not fetched; the cost contract is "no HTTP, no I/O."
+- `resolve_input()` — network-touching classification that resolves LNURL/Lightning Address inputs via HTTP, returning typed pay or withdraw request data. BOLT11 invoices and node IDs pass through without I/O.
+- `ParsedInput` enum (offline result): `Bolt11`, `NodeId`, `LnUrl { url }`, `LnUrlAddress { address }`
+- `ResolvedInput` enum (resolved result): `Bolt11`, `NodeId`, `LnUrlPay { data }`, `LnUrlWithdraw { data }`
 - Builder-style `Node` creation with signerless mode as default
 - `NodeState` snapshot with hex identifiers
 - `LogListener` for foreign-binding log capture
 - `generate_diagnostic_data()` for support dumps
-
-### Removed
-
-- `Node::resolve_lnurl()` and the `ResolvedLnUrl` enum. Use `parse_input()` (offline) or `resolve_input()` (HTTP) to obtain `LnUrlPayRequestData` / `LnUrlWithdrawRequestData`, then call `Node::lnurl_pay()` / `Node::lnurl_withdraw()`.
-
-### Fixed
-
-- Hardened LNURL-pay against real-world services
-- Excluded unpaid invoices from `list_payments`
-- `list_payments` fixes for edge cases
-
-## [0.2.0] - 2026-04-02
-
-### Added
-
 - `Node::get_info()` method for retrieving node identity and status
 - `Node::list_peers()` method for listing connected peers
 - `Node::list_peer_channels()` method for detailed channel information
@@ -48,18 +33,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Signer::new_from_seed()` constructor as an alternative to raw secret bytes
 - Top-level `register()`, `recover()`, `connect()`, and `register_or_recover()` convenience functions for simplified onboarding
 - `Config` type for SDK configuration (network, developer cert)
-- `parse_input()` function for parsing BOLT11 invoices and node IDs
 - `opening_fee_msat` field to `ReceiveResponse` reporting LSP JIT channel fees
 - Many new exported types: `GetInfoResponse`, `ListPeersResponse`, `ListPeerChannelsResponse`, `ListFundsResponse`, `ListInvoicesResponse`, `ListPaysResponse`, `ListPaymentsRequest`, `Invoice`, `InvoiceStatus`, `Pay`, `Payment`, `PaymentType`, `PaymentTypeFilter`, `PaymentStatus`, `ListIndex`, `Peer`, `PeerChannel`, `FundChannel`, `FundOutput`, `NodeEvent`, `NodeEventStream`, `InvoicePaidEvent`, `ChannelState`, `OutputStatus`
 
-### Fixed
-
-- Fixed msat parsing in `onchain_send` `amount_or_all` parameter
-
 ### Changed
 
+- `onchain_send()` now accepts optional `sat_per_vbyte` and `utxos` parameters for fee-rate control and UTXO pinning
+- Error variants now carry stable numeric `code`, human-readable `message`, and structured `values` map for i18n interpolation — replaces tuple-style error variants
+- `resolve_input()` is now **synchronous** — the entire public SDK API exposed through UniFFI is blocking, with async work handled internally on a shared Tokio runtime
+- Removed the `cpp-bindings` Cargo feature flag — a single build of the shared library now works for all language bindings (Python, Kotlin, Swift, Ruby, C++) without conditional compilation
 - Response types migrated from `uniffi::Object` to `uniffi::Record` so struct fields are directly accessible from bindings
 - Made `Credentials::load()`, `Credentials::save()`, `Node::receive()`, `Node::send()`, `Node::onchain_send()`, `Node::onchain_receive()`, `Signer::new()`, `Signer::authenticate()`, `Signer::start()`, `Signer::node_id()` public
+
+### Removed
+
+- `Node::resolve_lnurl()` and the `ResolvedLnUrl` enum. Use `parse_input()` (offline) or `resolve_input()` (HTTP) to obtain `LnUrlPayRequestData` / `LnUrlWithdrawRequestData`, then call `Node::lnurl_pay()` / `Node::lnurl_withdraw()`.
+
+### Fixed
+
+- Hardened LNURL-pay against real-world services
+- Excluded unpaid invoices from `list_payments`
+- `list_payments` fixes for edge cases
+- Fixed msat parsing in `onchain_send` `amount_or_all` parameter
 
 ## [0.1.1] - 2026-01-16
 
@@ -67,6 +62,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Updated gl-client dependency to support CLN v25.12 signer.
 
-[0.2.1]: https://github.com/Blockstream/greenlight/compare/gl-sdk-v0.2.0...gl-sdk-v0.2.1
-[0.2.0]: https://github.com/Blockstream/greenlight/compare/gl-sdk-v0.1.1...gl-sdk-v0.2.0
+[0.4.0]: https://github.com/Blockstream/greenlight/compare/gl-sdk-v0.1.1...gl-sdk-v0.4.0
 [0.1.1]: https://github.com/Blockstream/greenlight/releases/tag/gl-sdk-v0.1.1

--- a/libs/gl-sdk/Cargo.toml
+++ b/libs/gl-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl-sdk"
-version = "0.2.1"
+version = "0.4.0"
 edition = "2024"
 description = "High-level SDK for Greenlight with UniFFI language bindings"
 license = "MIT"
@@ -14,7 +14,7 @@ name = "glsdk"
 anyhow = "1"
 bip39 = "2.2.0"
 bitcoin = { version = "0.32", features = ["base64"] }
-gl-client = { version = "0.4.1", path = "../gl-client" }
+gl-client = { version = "0.6.0", path = "../gl-client" }
 hex = "0.4"
 log = "0.4"
 lightning-invoice = "0.33"

--- a/libs/gl-sdk/glsdk/__init__.py
+++ b/libs/gl-sdk/glsdk/__init__.py
@@ -6,4 +6,4 @@ client library, generated using Mozilla's UniFFI framework.
 
 from .glsdk import *  # noqa: F401, F403
 
-__version__ = "0.2.0"
+__version__ = "0.4.0"

--- a/libs/gl-sdk/pyproject.toml
+++ b/libs/gl-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gl-sdk"
-version = "0.2.1"
+version = "0.4.0"
 description = "Python bindings for Greenlight SDK using UniFFI"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release: gl-sdk v0.4

### Version bumps

| Package | From | To |
|---|---|---|
| **gl-client** (Rust) | 0.4.1 | **0.6.0** |
| **gl-sdk** (Rust) | 0.2.1 | **0.4.0** |
| **gl-sdk** (Python) | 0.2.1 | **0.4.0** |
| **gl-sdk-cli** | 0.1.1 | **0.3.0** |
| **gl-sdk-napi** (Rust + npm) | 0.1.1 | **0.2.0** |
| **gl-sdk-android** | 0.2.1 | **0.4.0** |

### Dependency bumps

| Dependent | Dependency | From | To |
|---|---|---|---|
| gl-sdk | gl-client | 0.4.1 | 0.6.0 |
| gl-plugin | gl-client | ^0.4.0 | ^0.6.0 |
| gl-cli | gl-client | 0.4 | 0.6 |

### Changelog updates

- **gl-client/CHANGELOG.md**: Merged `[0.4.1]` + `[0.4.0]` into `[0.6.0] - 2026-05-21` (LNURL module, signer improvements, metrics, VLS state sync, LSPS removal)
- **gl-sdk/CHANGELOG.md**: Merged `Unreleased` + `[0.2.1]` + `[0.2.0]` into `[0.4.0] - 2026-05-21`. Added missing entries for:
  - `prepare_onchain_send()`, `onchain_balance_state()`, `onchain_fee_rates()`
  - Stable numeric error codes with i18n interpolation values
  - C++ bindings support
  - `resolve_input()` made synchronous; `cpp-bindings` feature removed
- **gl-sdk-cli/CHANGELOG.md**: Merged `[0.1.1]` + `[0.1.0]` into `[0.3.0] - 2026-05-21`
- **gl-plugin/CHANGELOG.md**: Added LSPS2 `htlc_accepted` hook removal to Unreleased
- **gl-cli/CHANGELOG.md**: Added `--json` flag and private `fundchannel` default to Unreleased
- **Root CHANGELOG.md**: Moved signer fix from Unreleased into `[0.4.0] - 2026-05-21`

### Post-merge steps

After merging, tag and push concurrently to trigger crates.io publishing:

```bash
git tag gl-client-v0.6.0 && git tag gl-sdk-v0.4.0 && git tag gl-sdk-cli-v0.3.0
git push origin gl-client-v0.6.0 gl-sdk-v0.4.0 gl-sdk-cli-v0.3.0
```

Then trigger downstream binding releases:
- **Swift**: Dispatch `Publish Swift Bindings` workflow on `Blockstream/gl-sdk-swift` with version `2026w21-gl-sdk-0.4.0`
- **Android/Kotlin**: Trigger Maven deploy via GitLab CI
