### PR TITLE
plugin: Expand stuck HSM detection to cover onchaind signing types

### DIFF
--- a/libs/gl-plugin/src/stager.rs
+++ b/libs/gl-plugin/src/stager.rs
@@ -97,23 +97,42 @@ impl Stage {
         }
     }
 
-    pub async fn is_stuck(&self) -> bool {
-        let sticky_types: Vec<u16> = vec![5, 28];
-        let sticky: Vec<Request> = self
+    /// Returns the HSM request types currently queued that block node progress.
+    /// An empty vec means the node is not stuck.
+    pub async fn stuck_request_types(&self) -> Vec<u16> {
+        let sticky_types: Vec<u16> = vec![
+            5,   // WIRE_HSMD_SIGN_COMMITMENT_TX
+            12,  // WIRE_HSMD_SIGN_DELAYED_PAYMENT_TO_US
+            13,  // WIRE_HSMD_SIGN_REMOTE_HTLC_TO_US
+            14,  // WIRE_HSMD_SIGN_PENALTY_TO_US
+            20,  // WIRE_HSMD_SIGN_REMOTE_HTLC_TX
+            21,  // WIRE_HSMD_SIGN_MUTUAL_CLOSE_TX
+            28,  // WIRE_HSMD_CHECK_PUBKEY
+            142, // WIRE_HSMD_SIGN_ANY_DELAYED_PAYMENT_TO_US
+            143, // WIRE_HSMD_SIGN_ANY_REMOTE_HTLC_TO_US
+            144, // WIRE_HSMD_SIGN_ANY_PENALTY_TO_US
+            146, // WIRE_HSMD_SIGN_ANY_LOCAL_HTLC_TX
+            147, // WIRE_HSMD_SIGN_ANCHORSPEND
+            149, // WIRE_HSMD_SIGN_HTLC_TX_MINGLE
+        ];
+        let types: Vec<u16> = self
             .requests
             .lock()
             .await
             .values()
-            .filter(|r| {
+            .filter_map(|r| {
                 let head: [u16; 2] = [r.request.raw[0].into(), r.request.raw[1].into()];
                 let typ = head[0] << 8 | head[1];
-                sticky_types.contains(&typ)
+                if sticky_types.contains(&typ) { Some(typ) } else { None }
             })
-            .map(|r| r.clone())
             .collect();
 
-        trace!("Found {:?} sticky requests.", sticky);
-        sticky.len() != 0
+        trace!("Found stuck request types: {:?}", types);
+        types
+    }
+
+    pub async fn is_stuck(&self) -> bool {
+        !self.stuck_request_types().await.is_empty()
     }
 }
 


### PR DESCRIPTION
## Summary

- `is_stuck()` previously only checked for `SIGN_COMMITMENT_TX` (5) and `CHECK_PUBKEY` (28), missing all onchaind signing types. A bgsync node stuck waiting for e.g. `SIGN_ANY_REMOTE_HTLC_TO_US` (143) would spin silently for the full 10-minute session window without advancing its blockheight.
- Adds a `stuck_request_types() -> Vec<u16>` method that returns the blocking type numbers; `is_stuck()` now delegates to it.
- Expands the sticky type set to cover all onchaind signing operations: `SIGN_DELAYED_PAYMENT_TO_US` (12), `SIGN_REMOTE_HTLC_TO_US` (13), `SIGN_PENALTY_TO_US` (14), `SIGN_REMOTE_HTLC_TX` (20), `SIGN_MUTUAL_CLOSE_TX` (21), `SIGN_ANY_DELAYED_PAYMENT_TO_US` (142), `SIGN_ANY_REMOTE_HTLC_TO_US` (143), `SIGN_ANY_PENALTY_TO_US` (144), `SIGN_ANY_LOCAL_HTLC_TX` (146), `SIGN_ANCHORSPEND` (147), `SIGN_HTLC_TX_MINGLE` (149).

## Context

Discovered by inspecting bgsync session logs for a node stuck 124k blocks behind chain tip. The node had a unilateral close on one of its channels; onchaind fired when block 828110 was added and queued a `SIGN_ANY_REMOTE_HTLC_TO_US` (143) request to claim an expired HTLC timeout output. The signerproxy could not fulfil it, so the node blocked for ~9 minutes until the 10-minute preemption kicked in — making zero block progress per session.

## Test plan

- [ ] Verify `is_stuck()` still returns `false` when no requests are queued
- [ ] Verify `stuck_request_types()` returns the correct type numbers when onchaind signing requests are pending
- [ ] Confirm bgsync sessions for nodes with open/closed channels terminate early when the signer is unavailable

🤖 Generated with [Claude Code](https://claude.ai/claude-code)