### PR TITLE
plugin: Add GET_PER_COMMITMENT_POINT to stuck HSM types

### DIFF
--- a/libs/gl-plugin/src/stager.rs
+++ b/libs/gl-plugin/src/stager.rs
@@ -105,6 +105,7 @@ impl Stage {
             12,  // WIRE_HSMD_SIGN_DELAYED_PAYMENT_TO_US
             13,  // WIRE_HSMD_SIGN_REMOTE_HTLC_TO_US
             14,  // WIRE_HSMD_SIGN_PENALTY_TO_US
+            18,  // WIRE_HSMD_GET_PER_COMMITMENT_POINT (onchaind key derivation)
             20,  // WIRE_HSMD_SIGN_REMOTE_HTLC_TX
             21,  // WIRE_HSMD_SIGN_MUTUAL_CLOSE_TX
             28,  // WIRE_HSMD_CHECK_PUBKEY


### PR DESCRIPTION
## Summary

Follow-up to #724. Type 18 (`WIRE_HSMD_GET_PER_COMMITMENT_POINT`) is used by onchaind to derive historical commitment keys during force-close resolution. If the signer doesn't respond it blocks block processing just like the signing types added in the previous PR.

## Context

Inspecting the 10 worst-lagged bgsync nodes revealed 3 additional nodes stuck on type 18 — onchaind fires when hitting the block where a channel closed and requests historical per-commitment points to reconstruct keys for the HTLC sweep. The signerproxy can't fulfil these in the current bgsync sessions, so the node blocks for the full 10-minute window.

## Test plan

- [ ] Verify `stuck_request_types()` returns `[18]` when a `GET_PER_COMMITMENT_POINT` request is pending and unanswered

🤖 Generated with [Claude Code](https://claude.ai/claude-code)