### PR TITLE
feat(gl-signerproxy): convert to fully async tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -859,13 +859,13 @@ dependencies = [
  "futures-core",
  "hex",
  "log",
- "prost 0.12.6",
+ "prost",
  "serde",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1551,8 +1551,8 @@ dependencies = [
  "picky-asn1-der 0.4.1",
  "picky-asn1-x509 0.15.4",
  "pin-project",
- "prost 0.12.6",
- "prost-derive 0.12.6",
+ "prost",
+ "prost-derive",
  "rand",
  "rcgen",
  "reqwest",
@@ -1568,8 +1568,8 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic",
+ "tonic-build",
  "tower",
  "url",
  "uuid",
@@ -1591,13 +1591,13 @@ dependencies = [
  "hex",
  "log",
  "once_cell",
- "prost 0.12.6",
+ "prost",
  "pyo3",
  "runeauth",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -1636,7 +1636,7 @@ dependencies = [
  "linemux",
  "log",
  "nix",
- "prost 0.12.6",
+ "prost",
  "serde",
  "serde_json",
  "sled",
@@ -1644,8 +1644,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic",
+ "tonic-build",
  "tower",
  "vls-protocol",
 ]
@@ -1666,7 +1666,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
  "tracing",
  "uniffi",
  "url",
@@ -1712,10 +1712,10 @@ dependencies = [
  "env_logger 0.10.2",
  "libc",
  "log",
- "prost 0.11.9",
+ "prost",
  "tokio",
- "tonic 0.8.3",
- "tonic-build 0.8.4",
+ "tonic",
+ "tonic-build",
  "tower",
  "which",
 ]
@@ -1728,7 +1728,7 @@ dependencies = [
  "cln-rpc",
  "serde",
  "serde_json",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -1811,12 +1811,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2523,12 +2517,6 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
@@ -3134,16 +3122,6 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
@@ -3163,44 +3141,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap 0.8.3",
- "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3210,31 +3156,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck",
  "itertools 0.12.1",
  "log",
- "multimap 0.10.1",
+ "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.37",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prettyplease",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.117",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3252,20 +3185,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.6",
+ "prost",
 ]
 
 [[package]]
@@ -3602,18 +3526,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "log",
- "ring 0.16.20",
- "sct",
- "webpki",
 ]
 
 [[package]]
@@ -4395,17 +4307,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -4461,40 +4362,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "prost-derive 0.11.9",
- "rustls-pemfile 1.0.4",
- "tokio",
- "tokio-rustls 0.23.4",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
@@ -4511,7 +4378,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
+ "prost",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
@@ -4525,26 +4392,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
-dependencies = [
- "prettyplease 0.1.25",
- "proc-macro2",
- "prost-build 0.11.9",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
- "prettyplease 0.2.37",
+ "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
+ "prost-build",
  "quote",
  "syn 2.0.117",
 ]
@@ -4612,16 +4466,6 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -4742,7 +4586,7 @@ dependencies = [
  "fs-err",
  "glob",
  "goblin",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.14.0",
  "once_cell",
  "serde",
@@ -4827,7 +4671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.14.0",
  "tempfile",
  "uniffi_internal_macros",
@@ -5170,16 +5014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,7 +5328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -5505,9 +5339,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.14.0",
- "prettyplease 0.2.37",
+ "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -5521,7 +5355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease 0.2.37",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/libs/gl-signerproxy/Cargo.toml
+++ b/libs/gl-signerproxy/Cargo.toml
@@ -15,15 +15,14 @@ name = "gl-signerproxy"
 path = "src/bin/signerproxy.rs"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.11"
 
 [dependencies]
 anyhow = { workspace = true }
 env_logger = { workspace = true }
-# Minimal tokio - only for gRPC client runtime
 tokio = { version = "1", features = ["rt", "net", "io-util"] }
-tonic = { version = "0.8", features = ["tls", "transport"] }
-prost = "0.11"
+tonic = { version = "0.11", features = ["tls", "transport"] }
+prost = "0.12"
 log = "*"
 tower = "0.4"
 which = "4.4.2"

--- a/libs/gl-signerproxy/src/hsmproxy.rs
+++ b/libs/gl-signerproxy/src/hsmproxy.rs
@@ -1,21 +1,16 @@
-// Implementation of the server-side hsmd. It collects requests and passes
-// them on to the clients which actually have access to the keys.
 use crate::pb::{hsm_client::HsmClient, Empty, HsmRequest, HsmRequestContext};
 use crate::wire::{DaemonConnection, Message};
-use anyhow::{anyhow, Context};
-use anyhow::{Error, Result};
-use log::{debug, error, info, warn};
+use anyhow::{Context, Error, Result};
+use log::{info, warn};
 use std::convert::TryFrom;
 use std::env;
 use std::os::unix::io::{AsRawFd, FromRawFd};
-use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 use std::sync::atomic;
 use std::sync::Arc;
-use std::thread;
-use tokio::runtime::Runtime;
+use tokio::net::UnixStream;
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 use which::which;
@@ -33,7 +28,6 @@ struct NodeConnection {
 
 fn version() -> String {
     let path = which("lightning_hsmd").expect("could not find HSM executable in PATH");
-
     let version = Command::new(path)
         .args(&["--version"])
         .output()
@@ -42,132 +36,114 @@ fn version() -> String {
 }
 
 fn setup_node_stream() -> Result<DaemonConnection, Error> {
-    let ms = unsafe { UnixStream::from_raw_fd(3) };
-    Ok(DaemonConnection::new(ms))
+    let std_stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(3) };
+    std_stream.set_nonblocking(true)?;
+    let tok_stream = UnixStream::from_std(std_stream)?;
+    Ok(DaemonConnection::new(tok_stream))
 }
 
 fn start_handler(
     local: NodeConnection,
     counter: Arc<atomic::AtomicUsize>,
     grpc: GrpcClient,
-    runtime: Arc<Runtime>,
 ) {
-    thread::spawn(move || {
-        match process_requests(local, counter, grpc, runtime).context("processing requests") {
-            Ok(()) => panic!("why did the hsmproxy stop processing requests without an error?"),
-            Err(e) => warn!("hsmproxy stopped processing requests with error: {}", e),
+    tokio::spawn(async move {
+        match process_requests(local, counter, grpc).await {
+            Ok(()) => warn!("hsmproxy child handler exited without error"),
+            Err(e) => warn!("hsmproxy child handler exited: {}", e),
         }
     });
 }
 
-fn process_requests(
+async fn process_requests(
     node_conn: NodeConnection,
     request_counter: Arc<atomic::AtomicUsize>,
     mut server: GrpcClient,
-    runtime: Arc<Runtime>,
 ) -> Result<(), Error> {
-    let conn = node_conn.conn;
-    let context = node_conn.context;
+    let NodeConnection { mut conn, context } = node_conn;
+
     info!("Pinging server");
-    runtime.block_on(server.ping(Empty::default()))?;
+    server.ping(Empty::default()).await?;
+
     loop {
-        if let Ok(msg) = conn.read() {
-            match msg.msgtype() {
-                9 => {
-                    eprintln!("Got a message from node: {:?}", &msg.body);
-                    // This requests a new client fd with a given context,
-                    // handle it locally, and defer the creation of the client
-                    // fd on the server side until we need it.
-                    let ctx = HsmRequestContext::from_client_hsmfd_msg(&msg)?;
-                    eprintln!("Got a request for a new client fd. Context: {:?}", ctx);
+        let msg = conn.read().await?;
+        match msg.msgtype() {
+            9 => {
+                eprintln!("Got a message from node: {:?}", &msg.body);
+                let ctx = HsmRequestContext::from_client_hsmfd_msg(&msg)?;
+                eprintln!("Got a request for a new client fd. Context: {:?}", ctx);
 
-                    let (local, remote) = UnixStream::pair()?;
-                    let local = NodeConnection {
-                        conn: DaemonConnection::new(local),
-                        context: Some(ctx),
-                    };
-                    let remote = remote.as_raw_fd();
-                    let msg = Message::new_with_fds(vec![0, 109], &vec![remote]);
+                // Use std pair so remote is a blocking socket — CLN's C subdaemons
+                // use blocking I/O; O_NONBLOCK (set by tokio::pair) causes EAGAIN.
+                let (std_local, std_remote) = std::os::unix::net::UnixStream::pair()?;
+                let remote_fd = std_remote.as_raw_fd();
+                std_local.set_nonblocking(true)?;
+                let local = UnixStream::from_std(std_local)?;
+                let reply = Message::new_with_fds(vec![0, 109], &[remote_fd]);
 
-                    let grpc = server.clone();
-                    // Start new handler for the client
-                    start_handler(local, request_counter.clone(), grpc, runtime.clone());
-                    if let Err(e) = conn.write(msg) {
-                        error!("error writing msg to node_connection: {:?}", e);
-                        return Err(e);
-                    }
-                }
-		28 => {
-		    eprintln!("Locally handling the `hsmd_check_pubkey` call");
-		    let msg = Message::new(vec![0, 128, 1]);
-		    conn.write(msg)?
-		},
-                _ => {
-                    // By default we forward to the remote HSMd
-                    let req = tonic::Request::new(HsmRequest {
-                        context: context.clone(),
-                        raw: msg.body.clone(),
-                        request_id: request_counter.fetch_add(1, atomic::Ordering::Relaxed) as u32,
-                        requests: Vec::new(),
-                        signer_state: Vec::new(),
-                    });
+                let local_nc = NodeConnection {
+                    conn: DaemonConnection::new(local),
+                    context: Some(ctx),
+                };
+                start_handler(local_nc, request_counter.clone(), server.clone());
 
-                    eprintln!(
-                        "WIRE: lightningd -> hsmd: Got a message from node: {:?}",
-                        &req
-                    );
-                    let start_time = tokio::time::Instant::now();
-                    debug!("Got a message from node: {:?}", &req);
-                    let res = runtime.block_on(server.request(req))?.into_inner();
-                    let delta = start_time.elapsed();
-                    let msg = Message::from_raw(res.raw);
-                    eprintln!(
-                        "WIRE: plugin -> hsmd: Got respone from hsmd: {:?} after {}ms",
-                        &msg,
-                        delta.as_millis()
-                    );
-                    eprintln!("WIRE: hsmd -> lightningd: {:?}", &msg);
-                    conn.write(msg)?
-                }
+                conn.write(reply).await?;
+                drop(std_remote);
             }
-        } else {
-            error!("Connection lost");
-            return Err(anyhow!("Connection lost"));
+            28 => {
+                eprintln!("Locally handling the `hsmd_check_pubkey` call");
+                let reply = Message::new(vec![0, 128, 1]);
+                conn.write(reply).await?;
+            }
+            _ => {
+                let req = tonic::Request::new(HsmRequest {
+                    context: context.clone(),
+                    raw: msg.body.clone(),
+                    request_id: request_counter.fetch_add(1, atomic::Ordering::Relaxed) as u32,
+                    requests: Vec::new(),
+                    signer_state: Vec::new(),
+                });
+
+                eprintln!(
+                    "WIRE: lightningd -> hsmd: Got a message from node: {:?}",
+                    &req
+                );
+                let start = std::time::Instant::now();
+                let res = server.request(req).await?.into_inner();
+                let reply = Message::from_raw(res.raw);
+                eprintln!(
+                    "WIRE: plugin -> hsmd: Got response after {}ms: {:?}",
+                    start.elapsed().as_millis(),
+                    &reply,
+                );
+                conn.write(reply).await?;
+            }
         }
     }
 }
 
-fn grpc_connect(runtime: &Runtime) -> Result<GrpcClient, Error> {
-    runtime.block_on(async {
-        // We will ignore this uri because uds do not use it
-        // if your connector does use the uri it will be provided
-        // as the request to the `MakeConnection`.
-        // Connect to a Uds socket
-        let channel = Endpoint::try_from("http://[::]:50051")?
-            .connect_with_connector(service_fn(|_: Uri| {
-                let sock_path = get_sock_path().unwrap();
-                let mut path = PathBuf::new();
-                if !sock_path.starts_with('/') {
-                    path.push(env::current_dir().unwrap());
-                }
-                path.push(&sock_path);
+async fn grpc_connect() -> Result<GrpcClient, Error> {
+    let channel = Endpoint::try_from("http://[::]:50051")?
+        .connect_with_connector(service_fn(|_: Uri| {
+            let sock_path = get_sock_path().unwrap();
+            let mut path = PathBuf::new();
+            if !sock_path.starts_with('/') {
+                path.push(env::current_dir().unwrap());
+            }
+            path.push(&sock_path);
+            let path = path.to_str().unwrap().to_string();
+            info!("Connecting to hsmserver at {}", path);
+            tokio::net::UnixStream::connect(path)
+        }))
+        .await
+        .context("could not connect to the socket file")?;
 
-                let path = path.to_str().unwrap().to_string();
-                info!("Connecting to hsmserver at {}", path);
-                tokio::net::UnixStream::connect(path)
-            }))
-            .await
-            .context("could not connect to the socket file")?;
-
-        Ok(HsmClient::new(channel))
-    })
+    Ok(HsmClient::new(channel))
 }
 
 pub fn run() -> Result<(), Error> {
     let args: Vec<String> = std::env::args().collect();
 
-    // Start the counter at 1000 so we can inject some message before
-    // real requests if we want to.
     let request_counter = Arc::new(atomic::AtomicUsize::new(1000));
     if args.len() == 2 && args[1] == "--version" {
         println!("{}", version());
@@ -176,24 +152,21 @@ pub fn run() -> Result<(), Error> {
 
     info!("Starting hsmproxy");
 
-    // Create a dedicated tokio runtime for gRPC operations
-    let runtime = Arc::new(
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("failed to create tokio runtime")?,
-    );
-
-    let node = setup_node_stream()?;
-    let grpc = grpc_connect(&runtime)?;
-
-    process_requests(
-        NodeConnection {
-            conn: node,
-            context: None,
-        },
-        request_counter,
-        grpc,
-        runtime,
-    )
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to create tokio runtime")?
+        .block_on(async {
+            let node = setup_node_stream()?;
+            let grpc = grpc_connect().await?;
+            process_requests(
+                NodeConnection {
+                    conn: node,
+                    context: None,
+                },
+                request_counter,
+                grpc,
+            )
+            .await
+        })
 }

--- a/libs/gl-signerproxy/src/passfd.rs
+++ b/libs/gl-signerproxy/src/passfd.rs
@@ -1,120 +1,114 @@
 use libc::{self, c_int, c_uchar, c_void, msghdr};
 use log::trace;
-use std::io::{Error, ErrorKind};
+use std::io::{self, Error, ErrorKind};
 use std::mem;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
+use tokio::io::Interest;
+use tokio::net::UnixStream;
 
-pub trait SyncFdPassingExt {
-    /// Send RawFd. No type information is transmitted.
-    fn send_fd(&self, fd: RawFd) -> Result<(), Error>;
-    /// Receive RawFd. No type information is transmitted.
-    fn recv_fd(&self) -> Result<RawFd, Error>;
+fn try_send_fd(raw: RawFd, fd: RawFd) -> io::Result<()> {
+    trace!("Sending fd {}", fd);
+    let mut dummy: c_uchar = 0;
+    let msg_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ };
+    let mut buf = vec![0u8; msg_len];
+    let mut iov = libc::iovec {
+        iov_base: &mut dummy as *mut c_uchar as *mut c_void,
+        iov_len: mem::size_of_val(&dummy),
+    };
+    unsafe {
+        let hdr = libc::cmsghdr {
+            cmsg_level: libc::SOL_SOCKET,
+            cmsg_type: libc::SCM_RIGHTS,
+            cmsg_len: libc::CMSG_LEN(mem::size_of::<c_int>() as u32) as _,
+        };
+        #[allow(clippy::cast_ptr_alignment)]
+        std::ptr::write_unaligned(buf.as_mut_ptr() as *mut _, hdr);
+        #[allow(clippy::cast_ptr_alignment)]
+        std::ptr::write_unaligned(
+            libc::CMSG_DATA(buf.as_mut_ptr() as *const _) as *mut c_int,
+            fd,
+        );
+    }
+    let msg: msghdr = libc::msghdr {
+        msg_name: std::ptr::null_mut(),
+        msg_namelen: 0,
+        msg_iov: &mut iov,
+        msg_iovlen: 1,
+        msg_control: buf.as_mut_ptr() as *mut c_void,
+        msg_controllen: msg_len,
+        msg_flags: 0,
+    };
+    let rv = unsafe { libc::sendmsg(raw, &msg, libc::MSG_DONTWAIT) };
+    if rv < 0 {
+        return Err(Error::last_os_error());
+    }
+    Ok(())
 }
-impl SyncFdPassingExt for RawFd {
-    fn send_fd(&self, fd: RawFd) -> Result<(), Error> {
-        trace!("Sending fd {}", fd);
-        let mut dummy: c_uchar = 0;
-        let msg_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ };
-        let mut buf = vec![0u8; msg_len as usize];
-        let mut iov = libc::iovec {
-            iov_base: &mut dummy as *mut c_uchar as *mut c_void,
-            iov_len: mem::size_of_val(&dummy),
-        };
-        unsafe {
-            let hdr = libc::cmsghdr {
-                cmsg_level: libc::SOL_SOCKET,
-                cmsg_type: libc::SCM_RIGHTS,
-                cmsg_len: libc::CMSG_LEN(mem::size_of::<c_int>() as u32) as _,
-            };
-            // https://github.com/rust-lang/rust-clippy/issues/2881
-            #[allow(clippy::cast_ptr_alignment)]
-            std::ptr::write_unaligned(buf.as_mut_ptr() as *mut _, hdr);
 
-            // https://github.com/rust-lang/rust-clippy/issues/2881
-            #[allow(clippy::cast_ptr_alignment)]
-            std::ptr::write_unaligned(
-                libc::CMSG_DATA(buf.as_mut_ptr() as *const _) as *mut c_int,
-                fd,
-            );
+fn try_recv_fd(raw: RawFd) -> io::Result<RawFd> {
+    trace!("Receiving fd");
+    let mut dummy: c_uchar = 0;
+    let msg_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ };
+    let mut buf = vec![0u8; msg_len];
+    let mut iov = libc::iovec {
+        iov_base: &mut dummy as *mut c_uchar as *mut c_void,
+        iov_len: mem::size_of_val(&dummy),
+    };
+    let mut msg: msghdr = libc::msghdr {
+        msg_name: std::ptr::null_mut(),
+        msg_namelen: 0,
+        msg_iov: &mut iov,
+        msg_iovlen: 1,
+        msg_control: buf.as_mut_ptr() as *mut c_void,
+        msg_controllen: msg_len,
+        msg_flags: 0,
+    };
+    unsafe {
+        let rv = libc::recvmsg(raw, &mut msg, libc::MSG_DONTWAIT);
+        match rv {
+            0 => Err(Error::new(ErrorKind::UnexpectedEof, "0 bytes read")),
+            rv if rv < 0 => Err(Error::last_os_error()),
+            rv if rv == mem::size_of::<c_uchar>() as isize => {
+                let hdr: *mut libc::cmsghdr = if msg.msg_controllen as usize
+                    >= mem::size_of::<libc::cmsghdr>()
+                {
+                    msg.msg_control as *mut libc::cmsghdr
+                } else {
+                    return Err(Error::new(ErrorKind::InvalidData, "bad control msg (header)"));
+                };
+                if (*hdr).cmsg_level != libc::SOL_SOCKET || (*hdr).cmsg_type != libc::SCM_RIGHTS {
+                    return Err(Error::new(ErrorKind::InvalidData, "bad control msg (level)"));
+                }
+                if msg.msg_controllen as usize
+                    != libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as usize
+                {
+                    return Err(Error::new(ErrorKind::InvalidData, "bad control msg (len)"));
+                }
+                #[allow(clippy::cast_ptr_alignment)]
+                let fd = std::ptr::read_unaligned(libc::CMSG_DATA(hdr) as *mut c_int);
+                if libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) < 0 {
+                    return Err(Error::last_os_error());
+                }
+                Ok(fd)
+            }
+            _ => Err(Error::new(ErrorKind::InvalidData, "bad control msg (ret code)")),
         }
-        let msg: msghdr = libc::msghdr {
-            msg_name: std::ptr::null_mut(),
-            msg_namelen: 0,
-            msg_iov: &mut iov,
-            msg_iovlen: 1,
-            msg_control: buf.as_mut_ptr() as *mut c_void,
-            msg_controllen: msg_len,
-            msg_flags: 0,
-        };
+    }
+}
 
-        let rv = unsafe { libc::sendmsg(*self, &msg, 0) };
-        if rv < 0 {
-            return Err(Error::last_os_error());
-        }
+pub trait AsyncFdPassingExt {
+    async fn send_fd(&self, fd: RawFd) -> io::Result<()>;
+    async fn recv_fd(&self) -> io::Result<RawFd>;
+}
 
-        Ok(())
+impl AsyncFdPassingExt for UnixStream {
+    async fn send_fd(&self, fd: RawFd) -> io::Result<()> {
+        let raw = self.as_raw_fd();
+        self.async_io(Interest::WRITABLE, || try_send_fd(raw, fd)).await
     }
 
-    fn recv_fd(&self) -> Result<RawFd, Error> {
-        trace!("Receiving fd");
-        let mut dummy: c_uchar = 0;
-        let msg_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as _ };
-        let mut buf = vec![0u8; msg_len as usize];
-        let mut iov = libc::iovec {
-            iov_base: &mut dummy as *mut c_uchar as *mut c_void,
-            iov_len: mem::size_of_val(&dummy),
-        };
-        let mut msg: msghdr = libc::msghdr {
-            msg_name: std::ptr::null_mut(),
-            msg_namelen: 0,
-            msg_iov: &mut iov,
-            msg_iovlen: 1,
-            msg_control: buf.as_mut_ptr() as *mut c_void,
-            msg_controllen: msg_len,
-            msg_flags: 0,
-        };
-
-        unsafe {
-            let rv = libc::recvmsg(*self, &mut msg, 0);
-            match rv {
-                0 => Err(Error::new(ErrorKind::UnexpectedEof, "0 bytes read")),
-                rv if rv < 0 => Err(Error::last_os_error()),
-                rv if rv == mem::size_of::<c_uchar>() as isize => {
-                    let hdr: *mut libc::cmsghdr = if msg.msg_controllen as usize
-                        >= mem::size_of::<libc::cmsghdr>() as usize
-                    {
-                        msg.msg_control as *mut libc::cmsghdr
-                    } else {
-                        return Err(Error::new(
-                            ErrorKind::InvalidData,
-                            "bad control msg (header)",
-                        ));
-                    };
-                    if (*hdr).cmsg_level != libc::SOL_SOCKET || (*hdr).cmsg_type != libc::SCM_RIGHTS
-                    {
-                        return Err(Error::new(
-                            ErrorKind::InvalidData,
-                            "bad control msg (level)",
-                        ));
-                    }
-                    if msg.msg_controllen as usize
-                        != libc::CMSG_SPACE(mem::size_of::<c_int>() as u32) as usize
-                    {
-                        return Err(Error::new(ErrorKind::InvalidData, "bad control msg (len)"));
-                    }
-                    // https://github.com/rust-lang/rust-clippy/issues/2881
-                    #[allow(clippy::cast_ptr_alignment)]
-                    let fd = std::ptr::read_unaligned(libc::CMSG_DATA(hdr) as *mut c_int);
-                    if libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) < 0 {
-                        return Err(Error::last_os_error());
-                    }
-                    Ok(fd)
-                }
-                _ => Err(Error::new(
-                    ErrorKind::InvalidData,
-                    "bad control msg (ret code)",
-                )),
-            }
-        }
+    async fn recv_fd(&self) -> io::Result<RawFd> {
+        let raw = self.as_raw_fd();
+        self.async_io(Interest::READABLE, || try_recv_fd(raw)).await
     }
 }

--- a/libs/gl-signerproxy/src/wire.rs
+++ b/libs/gl-signerproxy/src/wire.rs
@@ -1,16 +1,13 @@
-use crate::passfd::SyncFdPassingExt;
-use anyhow::{anyhow, Error, Result};
+use crate::passfd::AsyncFdPassingExt;
+use anyhow::{Error, Result};
 use byteorder::{BigEndian, ByteOrder};
 use log::trace;
-use std::io::{Read, Write};
-use std::os::unix::io::{AsRawFd, RawFd};
-use std::os::unix::net::UnixStream;
-use std::sync::Mutex;
+use std::os::unix::io::RawFd;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
 
-/// A simple implementation of the inter-daemon protocol wrapping a
-/// UnixStream. Easy to read from and write to.
 pub struct DaemonConnection {
-    conn: Mutex<UnixStream>,
+    conn: UnixStream,
 }
 
 #[derive(Clone, Debug)]
@@ -45,6 +42,7 @@ impl Message {
         }
     }
 }
+
 impl PartialEq for Message {
     fn eq(&self, other: &Self) -> bool {
         self.body == other.body && self.typ == other.typ && self.fds == other.fds
@@ -52,10 +50,8 @@ impl PartialEq for Message {
 }
 
 impl DaemonConnection {
-    pub fn new(connection: UnixStream) -> DaemonConnection {
-        DaemonConnection {
-            conn: Mutex::new(connection),
-        }
+    pub fn new(conn: UnixStream) -> DaemonConnection {
+        DaemonConnection { conn }
     }
 
     fn count_fds(typ: u16) -> i8 {
@@ -65,58 +61,43 @@ impl DaemonConnection {
         }
     }
 
-    pub fn read(&self) -> Result<Message, Error> {
-        let mut sock = self.conn.lock().unwrap();
-
-        // Read 4-byte length prefix in big-endian
+    pub async fn read(&mut self) -> Result<Message, Error> {
         let mut len_buf = [0u8; 4];
-        sock.read_exact(&mut len_buf)?;
+        self.conn.read_exact(&mut len_buf).await?;
         let msglen = BigEndian::read_u32(&len_buf);
 
-        // Read the message body
         let mut buf = vec![0u8; msglen as usize];
-        sock.read_exact(&mut buf)?;
-
-        if buf.len() < msglen as usize {
-            return Err(anyhow!("Short read from client"));
-        }
+        self.conn.read_exact(&mut buf).await?;
 
         let typ = BigEndian::read_u16(&buf);
-        let mut fds = vec![];
-
-        // Receive any file descriptors associated with this message type
         let numfds = DaemonConnection::count_fds(typ);
+        let mut fds = vec![];
         for _ in 0..numfds {
-            fds.push(sock.as_raw_fd().recv_fd()?);
+            fds.push(self.conn.recv_fd().await.map_err(Error::from)?);
         }
 
-        if fds.len() == 0 {
+        if fds.is_empty() {
             Ok(Message::new(buf))
         } else {
             Ok(Message::new_with_fds(buf, &fds))
         }
     }
 
-    pub fn write(&self, msg: Message) -> Result<(), Error> {
+    pub async fn write(&mut self, msg: Message) -> Result<(), Error> {
         trace!(
             "Sending message {} ({} bytes, {} FDs)",
             msg.typ,
             msg.body.len(),
             msg.fds.len()
         );
-        let mut client = self.conn.lock().unwrap();
 
-        // Write 4-byte length prefix in big-endian
         let mut len_buf = [0u8; 4];
         BigEndian::write_u32(&mut len_buf, msg.body.len() as u32);
-        client.write_all(&len_buf)?;
+        self.conn.write_all(&len_buf).await?;
+        self.conn.write_all(&msg.body).await?;
 
-        // Write the message body
-        client.write_all(&msg.body)?;
-
-        // Send any file descriptors
         for fd in msg.fds {
-            client.as_raw_fd().send_fd(fd)?;
+            self.conn.send_fd(fd).await.map_err(Error::from)?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Replaces the sync/threaded `gl-signerproxy` architecture with a fully async Tokio implementation across three files (`passfd.rs`, `wire.rs`, `hsmproxy.rs`)
- New `AsyncFdPassingExt` trait on `tokio::net::UnixStream` uses `async_io()` + `MSG_DONTWAIT` to integrate SCM_RIGHTS fd passing with Tokio's readiness machinery
- Fixes a subtle O_NONBLOCK bug: `tokio::UnixStream::pair()` sets both ends non-blocking via mio; when the remote fd is passed to lightningd via `SCM_RIGHTS`, CLN's C subdaemons receive a non-blocking socket and immediately get `EAGAIN`. Fix: use `std::os::unix::net::UnixStream::pair()` for the remote end, then convert only the local end to Tokio
- Bumps tonic `0.8→0.11` and prost `0.11→0.12` to match the rest of the workspace

## Test plan

- [x] `cargo check --package gl-signerproxy` compiles cleanly
- [x] `pytest tests/test_all.py::test_gossipd_immediate_sync` passes (this is the test that caught the O_NONBLOCK bug)
- [x] `pytest tests/test_all.py::test_start` passes
- [x] `cargo tree -p gl-signerproxy --duplicates` shows no duplicate tokio or tonic

🤖 Generated with [Claude Code](https://claude.com/claude-code)