### PR TITLE
plugin: Increase the startup timeout for new nodes

### DIFF
--- a/libs/gl-plugin/src/node/rpcwait.rs
+++ b/libs/gl-plugin/src/node/rpcwait.rs
@@ -45,7 +45,7 @@ where
         let mut inner = std::mem::replace(&mut self.inner, clone);
         let path = self.rpc_path.clone();
         Box::pin(async move {
-            let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+            let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
             loop {
                 if deadline < tokio::time::Instant::now() {
                     // Break and let it fail in the `inner.call`


### PR DESCRIPTION
## Summary
- Increase the RPC-wait startup timeout in `gl-plugin` from 5s to 30s to accommodate slower initial DB initialization on first startup.

## Motivation
We have received some reports of spurious `No such file or directory` errors reported to the client, due to slow initial startups. The startup is slower than usual because the node needs to initialize its DB, and subsequent startups are much quicker, but allowing for a bit longer startup times results in a better UX.

## Test plan
- [x] Verify node startup no longer surfaces spurious `No such file or directory` errors during first-time DB initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)