### PR TITLE
ci: Authenticate arduino/setup-task API requests

### DIFF
--- a/.github/workflows/check-self.yml
+++ b/.github/workflows/check-self.yml
@@ -21,8 +21,8 @@ jobs:
 
     - name: Install Task
       uses: arduino/setup-task@v2
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/cln-version-manager-py.yml
+++ b/.github/workflows/cln-version-manager-py.yml
@@ -20,7 +20,9 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@v2
-        
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
         with:


### PR DESCRIPTION
`arduino/setup-task` queries the GitHub API to resolve and download the Task
release. Unauthenticated, those requests are rate limited per runner IP, and
that budget is shared across all GitHub-hosted runners. When it is exhausted
the step fails a few seconds into the job with:

```
##[error]API rate limit exceeded for 4.155.99.32. (But here's the good news:
Authenticated requests get a higher rate limit. ...)
```

This took down the `ClnVersionManager / source` job on an unrelated PR, and
will keep doing so at random. Passing `repo-token` authenticates the requests
so they get the much larger per-token allowance.

`check-self.yml` already tried to do this, but set `GH_TOKEN` in the step's
`env`. The action reads only the `repo-token` **input** — its `action.yml`
declares no env fallback — so that had no effect and the job was
unauthenticated too. Switched to the input.
