### PR TITLE
gl-plugin: make lsp_invoice RPC call store additional invoice metadata

### DIFF
--- a/libs/gl-plugin/src/node/mod.rs
+++ b/libs/gl-plugin/src/node/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::pb::{self, node_server::Node};
-use crate::storage::{LspInvoiceMeta, StateStore};
+use crate::storage::{JitRequestMeta, StateStore};
 use crate::{messages, Event};
 use crate::{stager, tramp};
 use anyhow::{anyhow, Context, Error, Result};
@@ -350,7 +350,7 @@ impl Node for PluginNodeServer {
         // A JIT channel has now been negotiated with the LSP for this
         // invoice. So, we're storing some data with the original requested
         // amount.
-        let meta = LspInvoiceMeta {
+        let meta = JitRequestMeta {
             label: invoice_label.clone(),
             payment_hash: res.payment_hash.clone(),
             requested_amount_msat,
@@ -859,7 +859,7 @@ impl Node for PluginNodeServer {
 
 /// Writes `LspInvoiceMeta` using datastore request. `LspInvoiceMeta` is useful for defining
 /// some additional information regarding invoice being requested trough Greenlight.
-async fn write_lsp_invoice_meta(rpc: &mut ClnRpc, meta: LspInvoiceMeta)
+async fn write_lsp_invoice_meta(rpc: &mut ClnRpc, meta: JitRequestMeta)
                                 -> Result<()> {
     let record_serialized =
         serde_json::to_string(&meta).context("failed to serialize LspInvoiceMeta")?;

--- a/libs/gl-plugin/src/node/mod.rs
+++ b/libs/gl-plugin/src/node/mod.rs
@@ -270,11 +270,14 @@ impl Node for PluginNodeServer {
                     label: req.label.clone(),
                     payment_hash: res.payment_hash.to_string(),
                     requested_amount_msat: req.amount_msat,
+                    expected_amount_msat: 0,
                     bolt11: res.bolt11.clone(),
+                    lsp_id: "".to_string(),
                 };
 
-                write_lsp_invoice_meta(rpc, meta).await
-                    .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
+                if let Err(e) = write_lsp_invoice_meta(&mut rpc, meta).await {
+                    warn!("Failed to write LSP invoice meta: {}", e);
+                }
 
                 return Ok(Response::new(pb::LspInvoiceResponse {
                     bolt11: res.bolt11,
@@ -364,11 +367,14 @@ impl Node for PluginNodeServer {
             label: invoice_label.clone(),
             payment_hash: res.payment_hash.clone(),
             requested_amount_msat,
+            expected_amount_msat: requested_amount_msat.saturating_sub(opening_fee_msat),
             bolt11: res.bolt11.clone(),
+            lsp_id,
         };
 
-        write_lsp_invoice_meta(rpc, meta).await
-            .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
+        if let Err(e) = write_lsp_invoice_meta(&mut rpc, meta).await {
+            warn!("Failed to write LSP invoice meta: {}", e);
+        }
 
         Ok(Response::new(res.into()))
     }
@@ -866,10 +872,10 @@ impl Node for PluginNodeServer {
 
 /// Writes `LspInvoiceMeta` using datastore request. `LspInvoiceMeta` is useful for defining
 /// some additional information regarding invoice being requested trough Greenlight.
-async fn write_lsp_invoice_meta(mut rpc: tokio::sync::MutexGuard<'_, ClnRpc>, meta: LspInvoiceMeta)
+async fn write_lsp_invoice_meta(rpc: &mut ClnRpc, meta: LspInvoiceMeta)
                                 -> Result<()> {
-    let record_serialized = serde_json::to_string(&meta)
-        .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
+    let record_serialized =
+        serde_json::to_string(&meta).context("failed to serialize LspInvoiceMeta")?;
 
     let datastore_req = cln_rpc::model::requests::DatastoreRequest {
         key: vec![

--- a/libs/gl-plugin/src/node/mod.rs
+++ b/libs/gl-plugin/src/node/mod.rs
@@ -1,12 +1,12 @@
 use crate::config::Config;
 use crate::pb::{self, node_server::Node};
-use crate::storage::StateStore;
+use crate::storage::{LspInvoiceMeta, StateStore};
 use crate::{messages, Event};
 use crate::{stager, tramp};
-use anyhow::{Context, Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use base64::{engine::general_purpose, Engine as _};
 use bytes::BufMut;
-use cln_rpc::Notification;
+use cln_rpc::{ClnRpc, Notification};
 use gl_client::metrics::{savings_percent, signer_state_request_wire_bytes};
 use gl_client::persist::{State, StateSketch};
 use governor::{
@@ -266,6 +266,16 @@ impl Node for PluginNodeServer {
                     .await
                     .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
 
+                let meta = LspInvoiceMeta {
+                    label: req.label.clone(),
+                    payment_hash: res.payment_hash.to_string(),
+                    requested_amount_msat: req.amount_msat,
+                    bolt11: res.bolt11.clone(),
+                };
+
+                write_lsp_invoice_meta(rpc, meta).await
+                    .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
+
                 return Ok(Response::new(pb::LspInvoiceResponse {
                     bolt11: res.bolt11,
                     created_index: res.created_index.unwrap_or(0) as u32,
@@ -326,6 +336,9 @@ impl Node for PluginNodeServer {
                 .div_ceil(1_000_000);
             std::cmp::max(min_fee, proportional_fee)
         };
+        
+        let requested_amount_msat = req.amount_msat.clone();
+        let invoice_label = req.label.clone();
 
         // Use the new RPC method name for versions > v25.05gl1
         let mut res = if *version > *"v25.05gl1" {
@@ -343,6 +356,20 @@ impl Node for PluginNodeServer {
         };
 
         res.opening_fee_msat = opening_fee_msat;
+
+        // A JIT channel has now been negotiated with the LSP for this
+        // invoice. So, we're storing some data with the original requested
+        // amount.
+        let meta = LspInvoiceMeta {
+            label: invoice_label.clone(),
+            payment_hash: res.payment_hash.clone(),
+            requested_amount_msat,
+            bolt11: res.bolt11.clone(),
+        };
+
+        write_lsp_invoice_meta(rpc, meta).await
+            .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
+
         Ok(Response::new(res.into()))
     }
 
@@ -835,6 +862,33 @@ impl Node for PluginNodeServer {
                 err.into()
             })
     }
+}
+
+/// Writes `LspInvoiceMeta` using datastore request. `LspInvoiceMeta` is useful for defining
+/// some additional information regarding invoice being requested trough Greenlight.
+async fn write_lsp_invoice_meta(mut rpc: tokio::sync::MutexGuard<'_, ClnRpc>, meta: LspInvoiceMeta)
+                                -> Result<()> {
+    let record_serialized = serde_json::to_string(&meta)
+        .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
+
+    let datastore_req = cln_rpc::model::requests::DatastoreRequest {
+        key: vec![
+            "gl".to_string(),
+            "jit_channels".to_string(),
+            meta.label,
+        ],
+        string: Some(record_serialized),
+        hex: None,
+        mode: Some(cln_rpc::model::requests::DatastoreMode::CREATE_OR_REPLACE),
+        generation: None,
+    };
+
+    rpc.call_typed(&datastore_req).await.map_err(
+        |e|
+            anyhow!("Failed to store JIT channel negotiation data in datastore: {}", e)
+    )?;
+
+    Ok(())
 }
 
 use cln_grpc::pb::node_server::NodeServer;

--- a/libs/gl-plugin/src/node/mod.rs
+++ b/libs/gl-plugin/src/node/mod.rs
@@ -266,19 +266,6 @@ impl Node for PluginNodeServer {
                     .await
                     .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
 
-                let meta = LspInvoiceMeta {
-                    label: req.label.clone(),
-                    payment_hash: res.payment_hash.to_string(),
-                    requested_amount_msat: req.amount_msat,
-                    expected_amount_msat: 0,
-                    bolt11: res.bolt11.clone(),
-                    lsp_id: "".to_string(),
-                };
-
-                if let Err(e) = write_lsp_invoice_meta(&mut rpc, meta).await {
-                    warn!("Failed to write LSP invoice meta: {}", e);
-                }
-
                 return Ok(Response::new(pb::LspInvoiceResponse {
                     bolt11: res.bolt11,
                     created_index: res.created_index.unwrap_or(0) as u32,

--- a/libs/gl-plugin/src/storage.rs
+++ b/libs/gl-plugin/src/storage.rs
@@ -2,6 +2,7 @@
 
 pub use gl_client::persist::State;
 use log::debug;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tonic::async_trait;
 
@@ -65,4 +66,23 @@ impl StateStore for SledStateStore {
             .map(|_v| ())
             .map_err(|e| e.into())
     }
+}
+
+/// A structure that is used for storing invoices that are requested through
+/// [Node::lsp_invoice](pb::node_server::Node::lsp_invoice) RPC call. lsp_invoice
+/// call does not guarantee that the returned invoice is for requesting JIT
+/// channel - if there is a channel with enough liquidity, a simple bolt11 invoice
+/// is created.
+///
+/// This structure is stored in CLN datastore. The reason of why do we need this
+/// structure instead of querying invoices table is that we want to distinguish
+/// incomming payments whether they were for JIT channel opening or just a simple
+/// payment. Currently, CLN does not allow to do so, that's why this workaround
+/// exists.
+#[derive(Serialize, Deserialize)]
+pub struct LspInvoiceMeta {
+    pub label: String,
+    pub payment_hash: String,
+    pub requested_amount_msat: u64,
+    pub bolt11: String,
 }

--- a/libs/gl-plugin/src/storage.rs
+++ b/libs/gl-plugin/src/storage.rs
@@ -68,23 +68,30 @@ impl StateStore for SledStateStore {
     }
 }
 
-/// A structure that is used for storing invoices that are requested through
-/// [Node::lsp_invoice](pb::node_server::Node::lsp_invoice) RPC call. lsp_invoice
-/// call does not guarantee that the returned invoice is for requesting JIT
-/// channel - if there is a channel with enough liquidity, a simple bolt11 invoice
-/// is created.
+/// A structure that is used for storing JIT channel requests metadata that is
+/// requested through [Node::lsp_invoice](pb::node_server::Node::lsp_invoice)
+/// RPC call.
 ///
 /// This structure is stored in CLN datastore. The reason of why do we need this
 /// structure instead of querying invoices table is that we want to distinguish
 /// incomming payments whether they were for JIT channel opening or just a simple
-/// payment. Currently, CLN does not allow to do so, that's why this workaround
+/// payment. Currently, CLN does not allow this, that's why this workaround
 /// exists.
 #[derive(Serialize, Deserialize)]
-pub struct LspInvoiceMeta {
+pub struct JitRequestMeta {
+    /// A label of the requested invoice.
     pub label: String,
+    /// Payment hash of the requested invoice.
     pub payment_hash: String,
+    /// The requested amount of msats.
     pub requested_amount_msat: u64,
+    /// The expected (reduced) amount if msats.
+    ///
+    /// Note that expected_amount_msat <= requested_amount_msat since
+    /// expected_amount_msat = requested_amount_msat + lsp_fee.
     pub expected_amount_msat: u64,
+    /// Original Bolt11 invoice which includes requested_amount_msat.
     pub bolt11: String,
+    /// ID of the LSP through which the invoice was requested.
     pub lsp_id: String,
 }

--- a/libs/gl-plugin/src/storage.rs
+++ b/libs/gl-plugin/src/storage.rs
@@ -84,5 +84,7 @@ pub struct LspInvoiceMeta {
     pub label: String,
     pub payment_hash: String,
     pub requested_amount_msat: u64,
+    pub expected_amount_msat: u64,
     pub bolt11: String,
+    pub lsp_id: String,
 }


### PR DESCRIPTION
# Problem
Currently, when a client requests for lsp invoice (JIT channel opening), no information about the original invoice is stored. Basically, the client hands out the requested invoice to a payer but receives only reduced amount. We'd like to have a way of understanding whether the requested invoice was for channel opening or a simple payment.

# Solution
Introduced a structure `LspInvoiceMeta` which contains all information that we need to store (specifically, bolt11 invoice). Use datastore requests in order to store metadata. `LspInvoiceMeta` is stored in both cases - if the invoice was requested from the LSP or not.

# Changes
- introduced `LspInvoiceMeta` structure for storing meta
- updated lsp_invoice RPC call to store `LspInvoiceMeta`